### PR TITLE
(#9) Add Download Progress

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/ChocolateyProgressInfo.cs
+++ b/src/NuGet.Core/NuGet.Protocol/ChocolateyProgressInfo.cs
@@ -1,0 +1,28 @@
+// Copyright (c) 2022-Present Chocolatey Software, Inc.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NuGet.Packaging.Core;
+
+namespace NuGet.Protocol
+{
+    public class ChocolateyProgressInfo
+    {
+        public ChocolateyProgressInfo(PackageIdentity identity, long? length = null, string operation = "")
+        {
+            Operation = operation;
+            Length = length;
+            Identity = identity;
+        }
+
+        public string Operation { get; set; }
+        public PackageIdentity Identity { get; set; }
+        public long? Length { get; set; }
+        public static bool ShouldDisplayDownloadProgress { get; set; }
+        public bool Completed { get; set; }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/ChocolateyProgressStream.cs
+++ b/src/NuGet.Core/NuGet.Protocol/ChocolateyProgressStream.cs
@@ -1,0 +1,61 @@
+// Copyright (c) 2022-Present Chocolatey Software, Inc.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+
+namespace NuGet.Protocol
+{
+    public delegate void StreamUpdate(Stream sender, long progress, long totalProgress);
+
+    // Based on https://www.thomasbogholm.net/2021/07/15/extend-streams-with-progress-reporting-progressreportingstream/
+    public class ChocolateyProgressStream : Stream
+    {
+        public ChocolateyProgressStream(Stream s)
+        {
+            InnerStream = s;
+        }
+
+        public event StreamUpdate WriteProgress;
+        public event StreamUpdate ReadProgress;
+
+        Stream InnerStream { get; }
+
+        private long _totalBytesRead;
+        private long _totalBytesWritten;
+
+        private void UpdateRead(long read)
+        {
+            _totalBytesRead += read;
+            ReadProgress?.Invoke(this, read, _totalBytesRead);
+        }
+
+        private void UpdateWritten(long written)
+        {
+            _totalBytesWritten += written;
+            WriteProgress?.Invoke(this, written, _totalBytesWritten);
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var result = InnerStream.Read(buffer, offset, count);
+            UpdateRead(result);
+            return result;
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            InnerStream.Write(buffer, offset, count);
+            UpdateWritten(count);
+        }
+
+        public override bool CanRead => InnerStream.CanRead;
+        public override bool CanSeek => InnerStream.CanSeek;
+        public override bool CanWrite => InnerStream.CanWrite;
+        public override long Length => InnerStream.Length;
+        public override long Position { get => InnerStream.Position; set => InnerStream.Position = value; }
+
+        public override void Flush() => InnerStream.Flush();
+        public override long Seek(long offset, SeekOrigin origin) => InnerStream.Seek(offset, origin);
+        public override void SetLength(long value) => InnerStream.SetLength(value);
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/IHttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/IHttpSource.cs
@@ -47,6 +47,14 @@ namespace NuGet.Protocol
             ILogger log,
             CancellationToken token);
 
+        Task<T> ProcessStreamAsync<T>(
+            HttpSourceRequest request,
+            Func<Stream, ChocolateyProgressInfo, Task<T>> processAsync,
+            SourceCacheContext cacheContext,
+            ILogger log,
+            ChocolateyProgressInfo progressInfo,
+            CancellationToken token);
+
         Task<T> ProcessResponseAsync<T>(
             HttpSourceRequest request,
             Func<HttpResponseMessage, Task<T>> processAsync,

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -16,6 +16,20 @@ NuGet.Protocol.Core.Types.DownloadCache.FileName.get -> string
 NuGet.Protocol.Core.Types.DownloadCache.FileName.set -> void
 NuGet.Protocol.Core.Types.DownloadCache.OriginalUrl.get -> string
 NuGet.Protocol.Core.Types.DownloadCache.OriginalUrl.set -> void
+NuGet.Protocol.ChocolateyProgressInfo
+NuGet.Protocol.ChocolateyProgressInfo.ChocolateyProgressInfo(NuGet.Packaging.Core.PackageIdentity identity, long? length = null, string operation = "") -> void
+NuGet.Protocol.ChocolateyProgressInfo.Completed.get -> bool
+NuGet.Protocol.ChocolateyProgressInfo.Completed.set -> void
+NuGet.Protocol.ChocolateyProgressInfo.Identity.get -> NuGet.Packaging.Core.PackageIdentity
+NuGet.Protocol.ChocolateyProgressInfo.Identity.set -> void
+NuGet.Protocol.ChocolateyProgressInfo.Length.get -> long?
+NuGet.Protocol.ChocolateyProgressInfo.Length.set -> void
+NuGet.Protocol.ChocolateyProgressInfo.Operation.get -> string
+NuGet.Protocol.ChocolateyProgressInfo.Operation.set -> void
+NuGet.Protocol.ChocolateyProgressStream
+NuGet.Protocol.ChocolateyProgressStream.ChocolateyProgressStream(System.IO.Stream s) -> void
+NuGet.Protocol.ChocolateyProgressStream.ReadProgress -> NuGet.Protocol.StreamUpdate
+NuGet.Protocol.ChocolateyProgressStream.WriteProgress -> NuGet.Protocol.StreamUpdate
 NuGet.Protocol.Core.Types.IPackageSearchMetadata.DownloadCache.get -> System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.DownloadCache>
 NuGet.Protocol.Core.Types.IPackageSearchMetadata.DownloadCacheDate.get -> System.DateTime?
 NuGet.Protocol.Core.Types.IPackageSearchMetadata.IsApproved.get -> bool
@@ -72,6 +86,7 @@ NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetada
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.VersionDownloadCount.get -> int?
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.VersionDownloadCount.set -> void
 NuGet.Protocol.HttpSource.ProcessHttpStreamAsync<T>(NuGet.Protocol.HttpSourceRequest request, System.Func<System.Net.Http.HttpResponseMessage, System.Threading.Tasks.Task<T>> processAsync, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>
+NuGet.Protocol.HttpSource.ProcessStreamAsync<T>(NuGet.Protocol.HttpSourceRequest request, System.Func<System.IO.Stream, NuGet.Protocol.ChocolateyProgressInfo, System.Threading.Tasks.Task<T>> processAsync, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger log, NuGet.Protocol.ChocolateyProgressInfo progressInfo, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>
 NuGet.Protocol.HttpSourceResource.OverrideHttpSource(NuGet.Protocol.IHttpSource source) -> void
 NuGet.Protocol.IHttpSource
 NuGet.Protocol.IHttpSource.GetAsync<T>(NuGet.Protocol.HttpSourceCachedRequest request, System.Func<NuGet.Protocol.HttpSourceResult, System.Threading.Tasks.Task<T>> processAsync, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>
@@ -82,6 +97,7 @@ NuGet.Protocol.IHttpSource.PackageSource.get -> string
 NuGet.Protocol.IHttpSource.ProcessHttpStreamAsync<T>(NuGet.Protocol.HttpSourceRequest request, System.Func<System.Net.Http.HttpResponseMessage, System.Threading.Tasks.Task<T>> processAsync, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>
 NuGet.Protocol.IHttpSource.ProcessResponseAsync<T>(NuGet.Protocol.HttpSourceRequest request, System.Func<System.Net.Http.HttpResponseMessage, System.Threading.Tasks.Task<T>> processAsync, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>
 NuGet.Protocol.IHttpSource.ProcessResponseAsync<T>(NuGet.Protocol.HttpSourceRequest request, System.Func<System.Net.Http.HttpResponseMessage, System.Threading.Tasks.Task<T>> processAsync, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>
+NuGet.Protocol.IHttpSource.ProcessStreamAsync<T>(NuGet.Protocol.HttpSourceRequest request, System.Func<System.IO.Stream, NuGet.Protocol.ChocolateyProgressInfo, System.Threading.Tasks.Task<T>> processAsync, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger log, NuGet.Protocol.ChocolateyProgressInfo progressInfo, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>
 NuGet.Protocol.IHttpSource.ProcessStreamAsync<T>(NuGet.Protocol.HttpSourceRequest request, System.Func<System.IO.Stream, System.Threading.Tasks.Task<T>> processAsync, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>
 NuGet.Protocol.IHttpSource.ProcessStreamAsync<T>(NuGet.Protocol.HttpSourceRequest request, System.Func<System.IO.Stream, System.Threading.Tasks.Task<T>> processAsync, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>
 NuGet.Protocol.IHttpSource.RetryHandler.get -> NuGet.Protocol.IHttpRetryHandler
@@ -161,6 +177,7 @@ NuGet.Protocol.PackageSearchMetadataV2Feed.PackageTestResultStatusDate.get -> Sy
 NuGet.Protocol.PackageSearchMetadataV2Feed.PackageValidationResultDate.get -> System.DateTime?
 NuGet.Protocol.PackageSearchMetadataV2Feed.PackageValidationResultStatus.get -> string
 NuGet.Protocol.PackageSearchMetadataV2Feed.VersionDownloadCount.get -> int?
+NuGet.Protocol.StreamUpdate
 NuGet.Protocol.V2FeedPackageInfo.DownloadCacheDate.get -> System.DateTime?
 NuGet.Protocol.V2FeedPackageInfo.DownloadCacheString.get -> string
 NuGet.Protocol.V2FeedPackageInfo.IsApproved.get -> bool
@@ -188,3 +205,17 @@ override NuGet.Protocol.LocalDependencyInfoResource.ResolvePackage(NuGet.Packagi
 override NuGet.Protocol.LocalDependencyInfoResource.ResolvePackages(string packageId, Chocolatey.NuGet.Frameworks.NuGetFramework projectFramework, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.SourcePackageDependencyInfo>>
 override NuGet.Protocol.Plugins.PluginPackageReader.GetSupportedFrameworks() -> System.Collections.Generic.IEnumerable<Chocolatey.NuGet.Frameworks.NuGetFramework>
 override NuGet.Protocol.Plugins.PluginPackageReader.GetSupportedFrameworksAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Chocolatey.NuGet.Frameworks.NuGetFramework>>
+override NuGet.Protocol.ChocolateyProgressStream.CanRead.get -> bool
+override NuGet.Protocol.ChocolateyProgressStream.CanSeek.get -> bool
+override NuGet.Protocol.ChocolateyProgressStream.CanWrite.get -> bool
+override NuGet.Protocol.ChocolateyProgressStream.Flush() -> void
+override NuGet.Protocol.ChocolateyProgressStream.Length.get -> long
+override NuGet.Protocol.ChocolateyProgressStream.Position.get -> long
+override NuGet.Protocol.ChocolateyProgressStream.Position.set -> void
+override NuGet.Protocol.ChocolateyProgressStream.Read(byte[] buffer, int offset, int count) -> int
+override NuGet.Protocol.ChocolateyProgressStream.Seek(long offset, System.IO.SeekOrigin origin) -> long
+override NuGet.Protocol.ChocolateyProgressStream.SetLength(long value) -> void
+override NuGet.Protocol.ChocolateyProgressStream.Write(byte[] buffer, int offset, int count) -> void
+static NuGet.Protocol.ChocolateyProgressInfo.ShouldDisplayDownloadProgress.get -> bool
+static NuGet.Protocol.ChocolateyProgressInfo.ShouldDisplayDownloadProgress.set -> void
+static NuGet.Protocol.GlobalPackagesFolderUtility.AddPackageAsync(string source, NuGet.Packaging.Core.PackageIdentity packageIdentity, System.IO.Stream packageStream, string globalPackagesFolder, System.Guid parentId, NuGet.Packaging.Signing.ClientPolicyContext clientPolicyContext, NuGet.Common.ILogger logger, System.Threading.CancellationToken token, NuGet.Protocol.ChocolateyProgressInfo progressInfo) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.DownloadResourceResult>

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -16,6 +16,20 @@ NuGet.Protocol.Core.Types.DownloadCache.FileName.get -> string
 NuGet.Protocol.Core.Types.DownloadCache.FileName.set -> void
 NuGet.Protocol.Core.Types.DownloadCache.OriginalUrl.get -> string
 NuGet.Protocol.Core.Types.DownloadCache.OriginalUrl.set -> void
+NuGet.Protocol.ChocolateyProgressInfo
+NuGet.Protocol.ChocolateyProgressInfo.ChocolateyProgressInfo(NuGet.Packaging.Core.PackageIdentity identity, long? length = null, string operation = "") -> void
+NuGet.Protocol.ChocolateyProgressInfo.Completed.get -> bool
+NuGet.Protocol.ChocolateyProgressInfo.Completed.set -> void
+NuGet.Protocol.ChocolateyProgressInfo.Identity.get -> NuGet.Packaging.Core.PackageIdentity
+NuGet.Protocol.ChocolateyProgressInfo.Identity.set -> void
+NuGet.Protocol.ChocolateyProgressInfo.Length.get -> long?
+NuGet.Protocol.ChocolateyProgressInfo.Length.set -> void
+NuGet.Protocol.ChocolateyProgressInfo.Operation.get -> string
+NuGet.Protocol.ChocolateyProgressInfo.Operation.set -> void
+NuGet.Protocol.ChocolateyProgressStream
+NuGet.Protocol.ChocolateyProgressStream.ChocolateyProgressStream(System.IO.Stream s) -> void
+NuGet.Protocol.ChocolateyProgressStream.ReadProgress -> NuGet.Protocol.StreamUpdate
+NuGet.Protocol.ChocolateyProgressStream.WriteProgress -> NuGet.Protocol.StreamUpdate
 NuGet.Protocol.Core.Types.IPackageSearchMetadata.DownloadCache.get -> System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.DownloadCache>
 NuGet.Protocol.Core.Types.IPackageSearchMetadata.DownloadCacheDate.get -> System.DateTime?
 NuGet.Protocol.Core.Types.IPackageSearchMetadata.IsApproved.get -> bool
@@ -72,6 +86,7 @@ NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetada
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.VersionDownloadCount.get -> int?
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.VersionDownloadCount.set -> void
 NuGet.Protocol.HttpSource.ProcessHttpStreamAsync<T>(NuGet.Protocol.HttpSourceRequest request, System.Func<System.Net.Http.HttpResponseMessage, System.Threading.Tasks.Task<T>> processAsync, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>
+NuGet.Protocol.HttpSource.ProcessStreamAsync<T>(NuGet.Protocol.HttpSourceRequest request, System.Func<System.IO.Stream, NuGet.Protocol.ChocolateyProgressInfo, System.Threading.Tasks.Task<T>> processAsync, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger log, NuGet.Protocol.ChocolateyProgressInfo progressInfo, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>
 NuGet.Protocol.HttpSourceResource.OverrideHttpSource(NuGet.Protocol.IHttpSource source) -> void
 NuGet.Protocol.IHttpSource
 NuGet.Protocol.IHttpSource.GetAsync<T>(NuGet.Protocol.HttpSourceCachedRequest request, System.Func<NuGet.Protocol.HttpSourceResult, System.Threading.Tasks.Task<T>> processAsync, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>
@@ -82,6 +97,7 @@ NuGet.Protocol.IHttpSource.PackageSource.get -> string
 NuGet.Protocol.IHttpSource.ProcessHttpStreamAsync<T>(NuGet.Protocol.HttpSourceRequest request, System.Func<System.Net.Http.HttpResponseMessage, System.Threading.Tasks.Task<T>> processAsync, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>
 NuGet.Protocol.IHttpSource.ProcessResponseAsync<T>(NuGet.Protocol.HttpSourceRequest request, System.Func<System.Net.Http.HttpResponseMessage, System.Threading.Tasks.Task<T>> processAsync, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>
 NuGet.Protocol.IHttpSource.ProcessResponseAsync<T>(NuGet.Protocol.HttpSourceRequest request, System.Func<System.Net.Http.HttpResponseMessage, System.Threading.Tasks.Task<T>> processAsync, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>
+NuGet.Protocol.IHttpSource.ProcessStreamAsync<T>(NuGet.Protocol.HttpSourceRequest request, System.Func<System.IO.Stream, NuGet.Protocol.ChocolateyProgressInfo, System.Threading.Tasks.Task<T>> processAsync, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger log, NuGet.Protocol.ChocolateyProgressInfo progressInfo, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>
 NuGet.Protocol.IHttpSource.ProcessStreamAsync<T>(NuGet.Protocol.HttpSourceRequest request, System.Func<System.IO.Stream, System.Threading.Tasks.Task<T>> processAsync, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>
 NuGet.Protocol.IHttpSource.ProcessStreamAsync<T>(NuGet.Protocol.HttpSourceRequest request, System.Func<System.IO.Stream, System.Threading.Tasks.Task<T>> processAsync, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>
 NuGet.Protocol.IHttpSource.RetryHandler.get -> NuGet.Protocol.IHttpRetryHandler
@@ -161,6 +177,7 @@ NuGet.Protocol.PackageSearchMetadataV2Feed.PackageTestResultStatusDate.get -> Sy
 NuGet.Protocol.PackageSearchMetadataV2Feed.PackageValidationResultDate.get -> System.DateTime?
 NuGet.Protocol.PackageSearchMetadataV2Feed.PackageValidationResultStatus.get -> string
 NuGet.Protocol.PackageSearchMetadataV2Feed.VersionDownloadCount.get -> int?
+NuGet.Protocol.StreamUpdate
 NuGet.Protocol.V2FeedPackageInfo.DownloadCacheDate.get -> System.DateTime?
 NuGet.Protocol.V2FeedPackageInfo.DownloadCacheString.get -> string
 NuGet.Protocol.V2FeedPackageInfo.IsApproved.get -> bool
@@ -188,3 +205,17 @@ override NuGet.Protocol.LocalDependencyInfoResource.ResolvePackage(NuGet.Packagi
 override NuGet.Protocol.LocalDependencyInfoResource.ResolvePackages(string packageId, Chocolatey.NuGet.Frameworks.NuGetFramework projectFramework, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.SourcePackageDependencyInfo>>
 override NuGet.Protocol.Plugins.PluginPackageReader.GetSupportedFrameworks() -> System.Collections.Generic.IEnumerable<Chocolatey.NuGet.Frameworks.NuGetFramework>
 override NuGet.Protocol.Plugins.PluginPackageReader.GetSupportedFrameworksAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Chocolatey.NuGet.Frameworks.NuGetFramework>>
+override NuGet.Protocol.ChocolateyProgressStream.CanRead.get -> bool
+override NuGet.Protocol.ChocolateyProgressStream.CanSeek.get -> bool
+override NuGet.Protocol.ChocolateyProgressStream.CanWrite.get -> bool
+override NuGet.Protocol.ChocolateyProgressStream.Flush() -> void
+override NuGet.Protocol.ChocolateyProgressStream.Length.get -> long
+override NuGet.Protocol.ChocolateyProgressStream.Position.get -> long
+override NuGet.Protocol.ChocolateyProgressStream.Position.set -> void
+override NuGet.Protocol.ChocolateyProgressStream.Read(byte[] buffer, int offset, int count) -> int
+override NuGet.Protocol.ChocolateyProgressStream.Seek(long offset, System.IO.SeekOrigin origin) -> long
+override NuGet.Protocol.ChocolateyProgressStream.SetLength(long value) -> void
+override NuGet.Protocol.ChocolateyProgressStream.Write(byte[] buffer, int offset, int count) -> void
+static NuGet.Protocol.ChocolateyProgressInfo.ShouldDisplayDownloadProgress.get -> bool
+static NuGet.Protocol.ChocolateyProgressInfo.ShouldDisplayDownloadProgress.set -> void
+static NuGet.Protocol.GlobalPackagesFolderUtility.AddPackageAsync(string source, NuGet.Packaging.Core.PackageIdentity packageIdentity, System.IO.Stream packageStream, string globalPackagesFolder, System.Guid parentId, NuGet.Packaging.Signing.ClientPolicyContext clientPolicyContext, NuGet.Common.ILogger logger, System.Threading.CancellationToken token, NuGet.Protocol.ChocolateyProgressInfo progressInfo) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.DownloadResourceResult>

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -16,6 +16,20 @@ NuGet.Protocol.Core.Types.DownloadCache.FileName.get -> string
 NuGet.Protocol.Core.Types.DownloadCache.FileName.set -> void
 NuGet.Protocol.Core.Types.DownloadCache.OriginalUrl.get -> string
 NuGet.Protocol.Core.Types.DownloadCache.OriginalUrl.set -> void
+NuGet.Protocol.ChocolateyProgressInfo
+NuGet.Protocol.ChocolateyProgressInfo.ChocolateyProgressInfo(NuGet.Packaging.Core.PackageIdentity identity, long? length = null, string operation = "") -> void
+NuGet.Protocol.ChocolateyProgressInfo.Completed.get -> bool
+NuGet.Protocol.ChocolateyProgressInfo.Completed.set -> void
+NuGet.Protocol.ChocolateyProgressInfo.Identity.get -> NuGet.Packaging.Core.PackageIdentity
+NuGet.Protocol.ChocolateyProgressInfo.Identity.set -> void
+NuGet.Protocol.ChocolateyProgressInfo.Length.get -> long?
+NuGet.Protocol.ChocolateyProgressInfo.Length.set -> void
+NuGet.Protocol.ChocolateyProgressInfo.Operation.get -> string
+NuGet.Protocol.ChocolateyProgressInfo.Operation.set -> void
+NuGet.Protocol.ChocolateyProgressStream
+NuGet.Protocol.ChocolateyProgressStream.ChocolateyProgressStream(System.IO.Stream s) -> void
+NuGet.Protocol.ChocolateyProgressStream.ReadProgress -> NuGet.Protocol.StreamUpdate
+NuGet.Protocol.ChocolateyProgressStream.WriteProgress -> NuGet.Protocol.StreamUpdate
 NuGet.Protocol.Core.Types.IPackageSearchMetadata.DownloadCache.get -> System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.DownloadCache>
 NuGet.Protocol.Core.Types.IPackageSearchMetadata.DownloadCacheDate.get -> System.DateTime?
 NuGet.Protocol.Core.Types.IPackageSearchMetadata.IsApproved.get -> bool
@@ -72,6 +86,7 @@ NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetada
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.VersionDownloadCount.get -> int?
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.VersionDownloadCount.set -> void
 NuGet.Protocol.HttpSource.ProcessHttpStreamAsync<T>(NuGet.Protocol.HttpSourceRequest request, System.Func<System.Net.Http.HttpResponseMessage, System.Threading.Tasks.Task<T>> processAsync, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>
+NuGet.Protocol.HttpSource.ProcessStreamAsync<T>(NuGet.Protocol.HttpSourceRequest request, System.Func<System.IO.Stream, NuGet.Protocol.ChocolateyProgressInfo, System.Threading.Tasks.Task<T>> processAsync, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger log, NuGet.Protocol.ChocolateyProgressInfo progressInfo, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>
 NuGet.Protocol.HttpSourceResource.OverrideHttpSource(NuGet.Protocol.IHttpSource source) -> void
 NuGet.Protocol.IHttpSource
 NuGet.Protocol.IHttpSource.GetAsync<T>(NuGet.Protocol.HttpSourceCachedRequest request, System.Func<NuGet.Protocol.HttpSourceResult, System.Threading.Tasks.Task<T>> processAsync, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>
@@ -82,6 +97,7 @@ NuGet.Protocol.IHttpSource.PackageSource.get -> string
 NuGet.Protocol.IHttpSource.ProcessHttpStreamAsync<T>(NuGet.Protocol.HttpSourceRequest request, System.Func<System.Net.Http.HttpResponseMessage, System.Threading.Tasks.Task<T>> processAsync, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>
 NuGet.Protocol.IHttpSource.ProcessResponseAsync<T>(NuGet.Protocol.HttpSourceRequest request, System.Func<System.Net.Http.HttpResponseMessage, System.Threading.Tasks.Task<T>> processAsync, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>
 NuGet.Protocol.IHttpSource.ProcessResponseAsync<T>(NuGet.Protocol.HttpSourceRequest request, System.Func<System.Net.Http.HttpResponseMessage, System.Threading.Tasks.Task<T>> processAsync, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>
+NuGet.Protocol.IHttpSource.ProcessStreamAsync<T>(NuGet.Protocol.HttpSourceRequest request, System.Func<System.IO.Stream, NuGet.Protocol.ChocolateyProgressInfo, System.Threading.Tasks.Task<T>> processAsync, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger log, NuGet.Protocol.ChocolateyProgressInfo progressInfo, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>
 NuGet.Protocol.IHttpSource.ProcessStreamAsync<T>(NuGet.Protocol.HttpSourceRequest request, System.Func<System.IO.Stream, System.Threading.Tasks.Task<T>> processAsync, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>
 NuGet.Protocol.IHttpSource.ProcessStreamAsync<T>(NuGet.Protocol.HttpSourceRequest request, System.Func<System.IO.Stream, System.Threading.Tasks.Task<T>> processAsync, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>
 NuGet.Protocol.IHttpSource.RetryHandler.get -> NuGet.Protocol.IHttpRetryHandler
@@ -161,6 +177,7 @@ NuGet.Protocol.PackageSearchMetadataV2Feed.PackageTestResultStatusDate.get -> Sy
 NuGet.Protocol.PackageSearchMetadataV2Feed.PackageValidationResultDate.get -> System.DateTime?
 NuGet.Protocol.PackageSearchMetadataV2Feed.PackageValidationResultStatus.get -> string
 NuGet.Protocol.PackageSearchMetadataV2Feed.VersionDownloadCount.get -> int?
+NuGet.Protocol.StreamUpdate
 NuGet.Protocol.V2FeedPackageInfo.DownloadCacheDate.get -> System.DateTime?
 NuGet.Protocol.V2FeedPackageInfo.DownloadCacheString.get -> string
 NuGet.Protocol.V2FeedPackageInfo.IsApproved.get -> bool
@@ -188,3 +205,17 @@ override NuGet.Protocol.LocalDependencyInfoResource.ResolvePackage(NuGet.Packagi
 override NuGet.Protocol.LocalDependencyInfoResource.ResolvePackages(string packageId, Chocolatey.NuGet.Frameworks.NuGetFramework projectFramework, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.SourcePackageDependencyInfo>>
 override NuGet.Protocol.Plugins.PluginPackageReader.GetSupportedFrameworks() -> System.Collections.Generic.IEnumerable<Chocolatey.NuGet.Frameworks.NuGetFramework>
 override NuGet.Protocol.Plugins.PluginPackageReader.GetSupportedFrameworksAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Chocolatey.NuGet.Frameworks.NuGetFramework>>
+override NuGet.Protocol.ChocolateyProgressStream.CanRead.get -> bool
+override NuGet.Protocol.ChocolateyProgressStream.CanSeek.get -> bool
+override NuGet.Protocol.ChocolateyProgressStream.CanWrite.get -> bool
+override NuGet.Protocol.ChocolateyProgressStream.Flush() -> void
+override NuGet.Protocol.ChocolateyProgressStream.Length.get -> long
+override NuGet.Protocol.ChocolateyProgressStream.Position.get -> long
+override NuGet.Protocol.ChocolateyProgressStream.Position.set -> void
+override NuGet.Protocol.ChocolateyProgressStream.Read(byte[] buffer, int offset, int count) -> int
+override NuGet.Protocol.ChocolateyProgressStream.Seek(long offset, System.IO.SeekOrigin origin) -> long
+override NuGet.Protocol.ChocolateyProgressStream.SetLength(long value) -> void
+override NuGet.Protocol.ChocolateyProgressStream.Write(byte[] buffer, int offset, int count) -> void
+static NuGet.Protocol.ChocolateyProgressInfo.ShouldDisplayDownloadProgress.get -> bool
+static NuGet.Protocol.ChocolateyProgressInfo.ShouldDisplayDownloadProgress.set -> void
+static NuGet.Protocol.GlobalPackagesFolderUtility.AddPackageAsync(string source, NuGet.Packaging.Core.PackageIdentity packageIdentity, System.IO.Stream packageStream, string globalPackagesFolder, System.Guid parentId, NuGet.Packaging.Signing.ClientPolicyContext clientPolicyContext, NuGet.Common.ILogger logger, System.Threading.CancellationToken token, NuGet.Protocol.ChocolateyProgressInfo progressInfo) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.DownloadResourceResult>

--- a/src/NuGet.Core/NuGet.Protocol/Utility/GetDownloadResultUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/GetDownloadResultUtility.cs
@@ -76,7 +76,10 @@ namespace NuGet.Protocol
                             IgnoreNotFounds = true,
                             MaxTries = 1
                         },
-                        async packageStream =>
+                        //////////////////////////////////////////////////////////
+                        // Start - Chocolatey Specific Modification
+                        //////////////////////////////////////////////////////////
+                        async (packageStream, progressInfo) =>
                         {
                             if (packageStream == null)
                             {
@@ -90,7 +93,8 @@ namespace NuGet.Protocol
                                     identity,
                                     packageStream,
                                     downloadContext,
-                                    token);
+                                    token,
+                                    progressInfo);
                             }
                             else
                             {
@@ -102,11 +106,16 @@ namespace NuGet.Protocol
                                     downloadContext.ParentId,
                                     downloadContext.ClientPolicyContext,
                                     logger,
-                                    token);
+                                    token,
+                                    progressInfo);
                             }
                         },
+                        //////////////////////////////////////////////////////////
+                        // End - Chocolatey Specific Modification
+                        //////////////////////////////////////////////////////////
                         downloadContext.SourceCacheContext,
                         logger,
+                        new ChocolateyProgressInfo(identity),
                         token);
                 }
                 catch (OperationCanceledException)
@@ -161,12 +170,16 @@ namespace NuGet.Protocol
             }
         }
 
+        //////////////////////////////////////////////////////////
+        // Start - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
         private static async Task<DownloadResourceResult> DirectDownloadAsync(
             string source,
             PackageIdentity packageIdentity,
             Stream packageStream,
             PackageDownloadContext downloadContext,
-            CancellationToken token)
+            CancellationToken token,
+            ChocolateyProgressInfo progressInfo)
         {
             if (packageIdentity == null)
             {
@@ -211,7 +224,27 @@ namespace NuGet.Protocol
                    BufferSize,
                    FileOptions.DeleteOnClose);
 
-                await packageStream.CopyToAsync(fileStream, BufferSize, token);
+                using (var progressPackageStream = new ChocolateyProgressStream(packageStream))
+                {
+                    progressPackageStream.ReadProgress += (sender, progress, totalProgress) =>
+                    {
+                        if (progressInfo.Length != null && ChocolateyProgressInfo.ShouldDisplayDownloadProgress && !progressInfo.Completed)
+                        {
+                            var percentComplete = ((double)totalProgress / (double)progressInfo.Length * 100);
+                            var progressString =
+                                $"Progress: {progressInfo.Operation} {progressInfo.Identity.Id} {progressInfo.Identity.Version}... {(percentComplete.ToString("##"))}";
+                            // http://stackoverflow.com/a/888569/18475
+                            Console.Write("\r{0}%", progressString);
+                            if (totalProgress == progressInfo.Length)
+                            {
+                                Console.WriteLine("");
+                                progressInfo.Completed = true;
+                            }
+                        }
+                    };
+
+                    await progressPackageStream.CopyToAsync(fileStream, BufferSize, token);
+                }
 
                 fileStream.Seek(0, SeekOrigin.Begin);
 
@@ -224,5 +257,8 @@ namespace NuGet.Protocol
                 throw;
             }
         }
+        //////////////////////////////////////////////////////////
+        // End - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
     }
 }


### PR DESCRIPTION
## Description Of Changes

This adds download progress to the console when `ChocolateyProgressInfo.ShouldDisplayDownloadProgress` is set to true. It works for both v2 and v3 feeds, but does not display for local feeds.

## Motivation and Context

Feature parity with v1

## Testing

- Build libraries and add to Choco
- Add `ChocolateyProgressInfo.ShouldDisplayDownloadProgress = config.Features.ShowDownloadProgress;` here:
https://github.com/chocolatey/choco/blob/cdd1c0036f4c092625886d71fbff2e628b838742/src/chocolatey/infrastructure.app/services/NugetService.cs#L747
- Build Choco
- Run `.\choco install wget --force`
- Run `.\choco install wget --force --no-progress`
- Run `.\choco install WGETWindows --force --source=https://api.nuget.org/v3/index.json`
- Run  `.\choco install WGETWindows --force --source=https://api.nuget.org/v3/index.json --no-progress`
- Validate that download is progress is shown or not shown as appropriate.

### Operating Systems Testing
- Windows 10 22H2

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

- Part of #9
https://app.clickup.com/t/20540031/PROJ-430