### PR TITLE
(#9) Don't step on NuGet paths

### DIFF
--- a/src/NuGet.Core/NuGet.Common/Migrations/MigrationRunner.cs
+++ b/src/NuGet.Core/NuGet.Common/Migrations/MigrationRunner.cs
@@ -13,6 +13,17 @@ namespace NuGet.Common.Migrations
 
         public static void Run()
         {
+            //////////////////////////////////////////////////////////
+            // Start - Chocolatey Specific Modification
+            //////////////////////////////////////////////////////////
+            // We don't want any chance of these migrations happening, even though they don't currently get called via code that Chocolatey CLI uses.
+            return;
+#pragma warning disable CS0162 // Unreachable code detected
+            //////////////////////////////////////////////////////////
+            // End - Chocolatey Specific Modification
+            //////////////////////////////////////////////////////////
+
+
             string migrationsDirectory = GetMigrationsDirectory();
             var expectedMigrationFilename = Path.Combine(migrationsDirectory, MaxMigrationFilename);
 
@@ -42,6 +53,14 @@ namespace NuGet.Common.Migrations
                     }
                 }
             }
+
+            //////////////////////////////////////////////////////////
+            // Start - Chocolatey Specific Modification
+            //////////////////////////////////////////////////////////
+#pragma warning disable CS0162 // Unreachable code detected
+            //////////////////////////////////////////////////////////
+            // End - Chocolatey Specific Modification
+            //////////////////////////////////////////////////////////
 
             static bool WaitForMutex(Mutex mutex)
             {

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/MigrationRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/MigrationRunnerTests.cs
@@ -13,7 +13,13 @@ namespace NuGet.Common.Test
     [CollectionDefinition("MigrationRunner", DisableParallelization = true)]
     public class MigrationRunnerTests
     {
-        [Fact]
+        //////////////////////////////////////////////////////////
+        // Start - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
+        [Fact(Skip = "Intentionally broken by Chocolatey changes")]
+        //////////////////////////////////////////////////////////
+        // End - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
         public void Run_WhenExecutedOnSingleThreadThenOneMigrationFileIsCreated_Success()
         {
             // Arrange
@@ -31,7 +37,13 @@ namespace NuGet.Common.Test
             Assert.Equal(Path.Combine(directory, "1"), files[0]);
         }
 
-        [Fact]
+        //////////////////////////////////////////////////////////
+        // Start - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
+        [Fact(Skip = "Intentionally broken by Chocolatey changes")]
+        //////////////////////////////////////////////////////////
+        // End - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
         public void Run_WhenExecutedInParallelThenOnlyOneMigrationFileIsCreated_Success()
         {
             var threads = new List<Thread>();


### PR DESCRIPTION
## Description Of Changes

This prevents migrations from happening, so it is not possible to
overwrite NuGet files. These migrations should not happen with
the code that Chocolatey calls, so this is extra insurance.

This changes the paths returned by NuGet.Environment when the
CHOCOLATEY_VERSION environment variable is set. This variable is set
when Chocolatey sets up it's configuration, so it is always set when
calling NuGet code within Chocolatey. Most of these paths should not
be used, so they are put in a folder under the cache location called
chocolatey-invalid. If this folder exists, then it means that there
is something in NuGet.Client that is not expected. The temp location
is used to get a location to put a lock file, so it is expected to be
used. Usage of this lock file would not interfere with NuGet, so even
if this code was to be bypassed, that part would not conflict with
NuGet.

## Motivation and Context

See description

## Testing

- Build PR
- Build choco with dlls from PR
- Run these commands, and ensure that nuget specific paths are not created/modified and that the `chocolatey-invalid` folder is not created in the Chocolatey cache location (by default `$env:temp\chocolatey`)
```
choco search wget
choco install wget
choco upgrade wget --force
choco uninstall wget
choco search chocolatey --source=https://api.nuget.org/v3/index.json
```

Paths for NuGet include:
`%localappdata\NuGet`
`%temp%\NuGetScratch`
`%userprofile%\.nuget`
`%programfilesx86%\NuGet`

### Operating Systems Testing
- Windows 10 22H2

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
Part of #9
https://app.clickup.com/t/20540031/PROJ-443