### PR TITLE
(#9) Return null for configuration elements

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -45,6 +45,17 @@ namespace NuGet.Configuration
 
         public SettingSection GetSection(string sectionName)
         {
+            //////////////////////////////////////////////////////////
+            // Start - Chocolatey Specific Modification
+            //////////////////////////////////////////////////////////
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CHOCOLATEY_VERSION")))
+            {
+                return null;
+            }
+            //////////////////////////////////////////////////////////
+            // End - Chocolatey Specific Modification
+            //////////////////////////////////////////////////////////
+
             if (_computedSections.TryGetValue(sectionName, out var section))
             {
                 return section.Clone() as SettingSection;

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingsFile.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingsFile.cs
@@ -143,6 +143,17 @@ namespace NuGet.Configuration
         /// <returns>null if no section with the given name was found</returns>
         public SettingSection GetSection(string sectionName)
         {
+            //////////////////////////////////////////////////////////
+            // Start - Chocolatey Specific Modification
+            //////////////////////////////////////////////////////////
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CHOCOLATEY_VERSION")))
+            {
+                return null;
+            }
+            //////////////////////////////////////////////////////////
+            // End - Chocolatey Specific Modification
+            //////////////////////////////////////////////////////////
+
             return _rootElement.GetSection(sectionName);
         }
 
@@ -194,6 +205,18 @@ namespace NuGet.Configuration
         /// </remarks>
         internal bool TryGetSection(string sectionName, out SettingSection section)
         {
+            //////////////////////////////////////////////////////////
+            // Start - Chocolatey Specific Modification
+            //////////////////////////////////////////////////////////
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CHOCOLATEY_VERSION")))
+            {
+                section = null;
+                return false;
+            }
+            //////////////////////////////////////////////////////////
+            // End - Chocolatey Specific Modification
+            //////////////////////////////////////////////////////////
+
             return _rootElement.Sections.TryGetValue(sectionName, out section);
         }
 


### PR DESCRIPTION
## Description Of Changes

This prevents any configuration from nuget.config files being returned to
prevent NuGet configuration from tainting Chocolatey

## Motivation and Context

See description

## Testing

Replace the return calls with throwing exceptions, and tested `choco search wget` and `choco install wget` to check if any calls to these methods are made.

I found that `Settings.GetSection()` is called when setting up the proxy for sources if there is not a proxy override specified, but no other calls to these methods is made.

### Operating Systems Testing
- Windows 22H2

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Part of #9
https://app.clickup.com/t/20540031/PROJ-444
