### PR TITLE
(#9) Disable telemetry emission

### DIFF
--- a/src/NuGet.Core/NuGet.Common/Telemetry/TelemetryActivity.cs
+++ b/src/NuGet.Core/NuGet.Common/Telemetry/TelemetryActivity.cs
@@ -51,6 +51,13 @@ namespace NuGet.Common
         /// End with <see cref="EndIntervalMeasure(string)"/>
         /// The intervals cannot overlap. For non-overlapping intervals <see cref="StartIndependentInterval(string)"/>
         /// </summary>
+        //////////////////////////////////////////////////////////
+        // Start - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
+        [Conditional("TELEMETRYCONDITION")]
+        //////////////////////////////////////////////////////////
+        // End - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
         public void StartIntervalMeasure()
         {
             _intervalWatch.Restart();
@@ -58,6 +65,13 @@ namespace NuGet.Common
 
         /// <summary> End interval measure. </summary>
         /// <param name="propertyName"> Property name to represents the interval. </param>
+        //////////////////////////////////////////////////////////
+        // Start - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
+        [Conditional("TELEMETRYCONDITION")]
+        //////////////////////////////////////////////////////////
+        // End - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
         public void EndIntervalMeasure(string propertyName)
         {
             _intervalWatch.Stop();
@@ -129,7 +143,15 @@ namespace NuGet.Common
                         TelemetryEvent[interval.Item1] = interval.Item2.TotalSeconds;
                     }
 
-                    NuGetTelemetryService.EmitTelemetryEvent(TelemetryEvent);
+                    //////////////////////////////////////////////////////////
+                    // Start - Chocolatey Specific Modification
+                    //////////////////////////////////////////////////////////
+
+                    //NuGetTelemetryService.EmitTelemetryEvent(TelemetryEvent);
+
+                    //////////////////////////////////////////////////////////
+                    // End - Chocolatey Specific Modification
+                    //////////////////////////////////////////////////////////
                 }
 
                 _telemetryActivity?.Dispose();
@@ -140,6 +162,13 @@ namespace NuGet.Common
 
         /// <summary> Emit a singular telemetry event. </summary>
         /// <param name="TelemetryEvent"> Telemetry event. </param>
+        //////////////////////////////////////////////////////////
+        // Start - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
+        [Conditional("TELEMETRYCONDITION")]
+        //////////////////////////////////////////////////////////
+        // End - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
         public static void EmitTelemetryEvent(TelemetryEvent TelemetryEvent)
         {
             NuGetTelemetryService?.EmitTelemetryEvent(TelemetryEvent);

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Actions/UIActionEngineTests.cs
@@ -214,7 +214,13 @@ namespace NuGet.PackageManagement.UI.Test
             }
         }
 
-        [Theory]
+        //////////////////////////////////////////////////////////
+        // Start - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
+        [Theory(Skip = "Intentionally broken by Chocolatey changes")]
+        //////////////////////////////////////////////////////////
+        // End - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
         [MemberData(nameof(GetInstallActionTestData))]
         public async Task CreateInstallAction_OnInstallingProject_EmitsPkgWasTransitiveTelemetryAndTabAndIsSolutionPropertiesAsync(ContractsItemFilter activeTab, bool isSolutionLevel, string packageIdToInstall, bool? expectedPkgWasTransitive)
         {

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
@@ -2386,7 +2386,13 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             }
         }
 
-        [Fact]
+        //////////////////////////////////////////////////////////
+        // Start - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
+        [Fact(Skip = "Intentionally broken by Chocolatey changes")]
+        //////////////////////////////////////////////////////////
+        // End - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
         public async Task TestPackageManager_RaiseTelemetryEvents()
         {
             // set up telemetry service

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetPackageSearchServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetPackageSearchServiceTests.cs
@@ -433,7 +433,13 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             Assert.Null(recommender);
         }
 
-        [Fact]
+        //////////////////////////////////////////////////////////
+        // Start - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
+        [Fact(Skip = "Intentionally broken by Chocolatey changes")]
+        //////////////////////////////////////////////////////////
+        // End - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
         public async Task CreatePackageFeedAsync_ProjectPMUIInstalledTab_EmitsCounterfactualTelemetryAsync()
         {
             // Arrange

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
@@ -368,7 +368,13 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             }
         }
 
-        [Fact]
+        //////////////////////////////////////////////////////////
+        // Start - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
+        [Fact(Skip = "Intentionally broken by Chocolatey changes")]
+        //////////////////////////////////////////////////////////
+        // End - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
         public async Task GetInstalledPackagesAsync_WhenProjectReturnsNullPackageReference_NullIsRemoved()
         {
             const string projectName = "a";
@@ -799,7 +805,13 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 x => Assert.Equal(x.Identity, new PackageIdentity("packageX", NuGetVersion.Parse("3.0.0"))));
         }
 
-        [Fact]
+        //////////////////////////////////////////////////////////
+        // Start - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
+        [Fact(Skip = "Intentionally broken by Chocolatey changes")]
+        //////////////////////////////////////////////////////////
+        // End - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
         private async Task GetInstalledAndTransitivePackagesAsync_WithCpsPackageReferenceProject_OneTransitiveReferenceAndEmitsCounterfactualTelemetryAsync()
         {
             // packageA_2.0.0 -> packageB_1.0.0

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/TelemetryOnceEmitterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/TelemetryOnceEmitterTests.cs
@@ -38,7 +38,13 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             Assert.Throws<ArgumentException>(() => new TelemetryOnceEmitter(eventName));
         }
 
-        [Fact]
+        //////////////////////////////////////////////////////////
+        // Start - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
+        [Fact(Skip = "Intentionally broken by Chocolatey changes")]
+        //////////////////////////////////////////////////////////
+        // End - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
         public void EmitIfNeeded_TwoCalls_EmitsTelemetryOnce()
         {
             // Arrange
@@ -54,7 +60,13 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             Assert.Equal(1, _telemetryEvents.Count);
         }
 
-        [Fact]
+        //////////////////////////////////////////////////////////
+        // Start - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
+        [Fact(Skip = "Intentionally broken by Chocolatey changes")]
+        //////////////////////////////////////////////////////////
+        // End - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
         public async Task EmitIfNeeded_MultipleThreads_EmitsOnceAsync()
         {
             // Arrange
@@ -84,7 +96,13 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             Assert.Contains(_telemetryEvents, e => e.Name == logger.EventName);
         }
 
-        [Fact]
+        //////////////////////////////////////////////////////////
+        // Start - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
+        [Fact(Skip = "Intentionally broken by Chocolatey changes")]
+        //////////////////////////////////////////////////////////
+        // End - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////]
         public void Reset_WithAlreadyEmitted_Restarts()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommand/OriginalCaseGlobalPackageFolderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommand/OriginalCaseGlobalPackageFolderTests.cs
@@ -187,7 +187,13 @@ namespace NuGet.Commands.Test
             }
         }
 
-        [Fact]
+        //////////////////////////////////////////////////////////
+        // Start - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
+        [Fact(Skip = "Intentionally broken by Chocolatey changes")]
+        //////////////////////////////////////////////////////////
+        // End - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
         public async Task CopyPackagesToOriginalCaseAsync_EmitsTelemetryWithParentIdAsync()
         {
             // Set up telemetry service

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -2692,7 +2692,13 @@ namespace NuGet.Commands.Test
             }
         }
 
-        [Fact]
+        //////////////////////////////////////////////////////////
+        // Start - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
+        [Fact(Skip = "Intentionally broken by Chocolatey changes")]
+        //////////////////////////////////////////////////////////
+        // End - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
         public async Task ExecuteAsync_WithSinglePackage_PopulatesCorrectTelemetry()
         {
             // Arrange
@@ -2765,7 +2771,13 @@ namespace NuGet.Commands.Test
             projectInformationEvent["FallbackFoldersCount"].Should().Be(0);
         }
 
-        [Fact]
+        //////////////////////////////////////////////////////////
+        // Start - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
+        [Fact(Skip = "Intentionally broken by Chocolatey changes")]
+        //////////////////////////////////////////////////////////
+        // End - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
         public async Task ExecuteAsync_WithSinglePackage_WhenNoOping_PopulatesCorrectTelemetry()
         {
             // Arrange
@@ -2841,7 +2853,13 @@ namespace NuGet.Commands.Test
             projectInformationEvent["FallbackFoldersCount"].Should().Be(0);
         }
 
-        [Fact]
+        //////////////////////////////////////////////////////////
+        // Start - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
+        [Fact(Skip = "Intentionally broken by Chocolatey changes")]
+        //////////////////////////////////////////////////////////
+        // End - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
         public async Task ExecuteAsync_WithPartiallyPopulatedGlobalPackagesFolder_PopulatesNewlyInstalledPackagesTelemetry()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/TelemetryActivityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/TelemetryActivityTests.cs
@@ -35,7 +35,13 @@ namespace NuGet.Common.Test
             TelemetryActivity.NuGetTelemetryService = _telemetryService.Object;
         }
 
-        [Fact]
+        //////////////////////////////////////////////////////////
+        // Start - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
+        [Fact(Skip = "Intentionally broken by Chocolatey changes")]
+        //////////////////////////////////////////////////////////
+        // End - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
         public void Dispose_WithOperationIdAndWithoutParentId_EmitsOperationIdAndNotParentId()
         {
             Guid operationId;
@@ -49,7 +55,13 @@ namespace NuGet.Common.Test
             Assert.Equal(operationId.ToString(), _telemetryEvent["OperationId"]);
         }
 
-        [Fact]
+        //////////////////////////////////////////////////////////
+        // Start - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
+        [Fact(Skip = "Intentionally broken by Chocolatey changes")]
+        //////////////////////////////////////////////////////////
+        // End - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
         public void Dispose_WithOperationIdAndParentId_EmitsOperationIdAndParentId()
         {
             var parentId = Guid.NewGuid();
@@ -64,7 +76,13 @@ namespace NuGet.Common.Test
             Assert.Equal(operationId.ToString(), _telemetryEvent["OperationId"]);
         }
 
-        [Fact]
+        //////////////////////////////////////////////////////////
+        // Start - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
+        [Fact(Skip = "Intentionally broken by Chocolatey changes")]
+        //////////////////////////////////////////////////////////
+        // End - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
         public void Dispose_WithIntervalMeasure_EmitsIntervalMeasure()
         {
             const string measureName = "testInterval";
@@ -83,7 +101,13 @@ namespace NuGet.Common.Test
             Assert.True(actualCount >= secondsToWait, $"The telemetry duration count should at least be {secondsToWait} seconds.");
         }
 
-        [Fact]
+        //////////////////////////////////////////////////////////
+        // Start - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
+        [Fact(Skip = "Intentionally broken by Chocolatey changes")]
+        //////////////////////////////////////////////////////////
+        // End - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
         public void Dispose_WithEmptyParentId_EmitsNoParentId()
         {
             var parentId = Guid.Empty;
@@ -95,7 +119,13 @@ namespace NuGet.Common.Test
             Assert.Null(_telemetryEvent["ParentId"]);
         }
 
-        [Fact]
+        //////////////////////////////////////////////////////////
+        // Start - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
+        [Fact(Skip = "Intentionally broken by Chocolatey changes")]
+        //////////////////////////////////////////////////////////
+        // End - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
         public void Dispose_Always_EmitsStartTime()
         {
             using (var telemetry = TelemetryActivity.Create(CreateNewTelemetryEvent()))
@@ -109,7 +139,13 @@ namespace NuGet.Common.Test
             TelemetryUtility.VerifyDateTimeFormat(startTime);
         }
 
-        [Fact]
+        //////////////////////////////////////////////////////////
+        // Start - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
+        [Fact(Skip = "Intentionally broken by Chocolatey changes")]
+        //////////////////////////////////////////////////////////
+        // End - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
         public void Dispose_Always_EmitsEndTime()
         {
             using (var telemetry = TelemetryActivity.Create(CreateNewTelemetryEvent()))
@@ -123,7 +159,13 @@ namespace NuGet.Common.Test
             TelemetryUtility.VerifyDateTimeFormat(endTime);
         }
 
-        [Fact]
+        //////////////////////////////////////////////////////////
+        // Start - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
+        [Fact(Skip = "Intentionally broken by Chocolatey changes")]
+        //////////////////////////////////////////////////////////
+        // End - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
         public void Dispose_Always_EmitsDuration()
         {
             using (var telemetry = TelemetryActivity.Create(CreateNewTelemetryEvent()))
@@ -156,7 +198,13 @@ namespace NuGet.Common.Test
             Assert.True(_activityDisposed);
         }
 
-        [Fact]
+        //////////////////////////////////////////////////////////
+        // Start - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
+        [Fact(Skip = "Intentionally broken by Chocolatey changes")]
+        //////////////////////////////////////////////////////////
+        // End - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
         public void Dispose_IndependentInterval_EmitsIntervalMeasure()
         {
             const string measureName = nameof(Dispose_IndependentInterval_EmitsIntervalMeasure);
@@ -176,7 +224,13 @@ namespace NuGet.Common.Test
             Assert.True(actualCount >= secondsToWait, $"The telemetry duration count should at least be {secondsToWait} seconds.");
         }
 
-        [Fact]
+        //////////////////////////////////////////////////////////
+        // Start - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
+        [Fact(Skip = "Intentionally broken by Chocolatey changes")]
+        //////////////////////////////////////////////////////////
+        // End - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
         public void Dispose_WithIndependentInterval_DoesNotClashWithNonoverlappingInterval()
         {
             const string independentInterval = "independentTestInterval";


### PR DESCRIPTION
## Description Of Changes

This disables sending of telemetry information to implementations of the `INuGetTelemetryService` service, so if a telemetry sending implementation is added to the NuGet SDK assemblies in the future, then it will not have anything to send. This disables both sending of individual telemetry events, and sending a summary as the event is disposed.

## Motivation and Context

Chocolatey has a policy of not 'phoning home' so it's critical that the NuGet libraries do not send any telemetry. This change insurance against future upstream changes enabling telemetry in the libraries.

## Testing

Here is call to `TelemetryActivity.EmitTelemetryEvent` in `NuGet.PackageManagement.PackagePreFetcherResult.EmitTelemetryEvent`.
https://github.com/chocolatey/NuGet.Client/blob/7512130598b682d40a5f0b206613aa185662f9fd/src/NuGet.Core/NuGet.PackageManagement/PackagePreFetcherResult.cs#L183-L200

Here is a screenshot of a dotpeek decompilation of that method 
![image](https://user-images.githubusercontent.com/38865330/211868370-d3a292f9-6537-4ed9-bf88-f16dd61e6b7b.png)

As shown in the decompilation, the call to `TelemetryActivity.EmitTelemetryEvent` is not compiled into the MSIL code.

### Operating Systems Testing
- Windows 10 22H2

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Part of #9
https://app.clickup.com/t/20540031/PROJ-445