### PR TITLE
(#9) Add fallback to read nupkg file on local sources

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Utility/LocalFolderUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/LocalFolderUtility.cs
@@ -543,6 +543,23 @@ namespace NuGet.Protocol
             {
                 return new PackageIdentity(id, version);
             }
+            //////////////////////////////////////////////////////////
+            // Start - Chocolatey Specific Modification
+            //////////////////////////////////////////////////////////
+            else if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CHOCOLATEY_VERSION"))
+                && file != null
+                && file.Extension.Equals(PackagingCoreConstants.NupkgExtension, StringComparison.OrdinalIgnoreCase))
+            {
+                var localPackage = GetPackageFromNupkg(file);
+
+                if (localPackage?.Identity != null && localPackage.Identity.Id.Equals(id, StringComparison.OrdinalIgnoreCase))
+                {
+                    return localPackage.Identity;
+                }
+            }
+            //////////////////////////////////////////////////////////
+            // End - Chocolatey Specific Modification
+            //////////////////////////////////////////////////////////
 
             return null;
         }


### PR DESCRIPTION
## Description Of Changes

This pull request updates the logic to reading packages to instead of
just grabbing the identifier and version from the file name, it will
fall back to reading the package archive itself if the previous method
was not successful.

## Motivation and Context

Because locally installed packages in Chocolatey CLI is saving the nupkg and nuspec files without a version number, we are unable to locate this packages when we search for an exact package.

## Testing

1. Build the project with the `Debug` configuration
2. Copy over the built binaries to the chocolatey/choco local repository
3. Debug the application using the arguments `list chocolatey -li --exact`
4. Debug the application using the argument `list firefox --exact`
5. Both calls should list out the found packages

### Operating Systems Testing

- Windows 10/11

## Change Types Made

* [x] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added. (Tests has not been updated, as I do not know which are affected by localization and which may have been affected by the update, tests will instead be enabled or added to Chocolatey CLI E2E)
* [ ] All new and existing tests passed? (More tests has been made English only since the last update, unable to verify whether they succeed or not)
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

#9  
https://github.com/chocolatey/choco/issues/508  
https://app.clickup.com/t/20540031/PROJ-457