### PR TITLE
(#9) Change defaults for capabilities of a feed

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/LegacyFeedCapabilityResourceV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/LegacyFeedCapabilityResourceV2Feed.cs
@@ -91,6 +91,21 @@ namespace NuGet.Protocol
             catch
             {
                 // If there is a failure getting the metadata, assume default capabilities.
+
+                //////////////////////////////////////////////////////////
+                // Start - Chocolatey Specific Modification
+                //////////////////////////////////////////////////////////
+
+                // If we are unable to grab information directly from the metadata URL for a source
+                // regarding what capabilities that it has, let's assume that it can't do either of
+                // the following.  This is in-keeping with what was done in the original NuGet.Core
+                // assembly.
+                capabilities.SupportsIsAbsoluteLatestVersion = false;
+                capabilities.SupportsSearch = false;
+
+                //////////////////////////////////////////////////////////
+                // End - Chocolatey Specific Modification
+                //////////////////////////////////////////////////////////
             }
 
             return capabilities;


### PR DESCRIPTION
## Description Of Changes

In the NuGet.Client assemblies, if it isn't possible to ascertain what methods are supported from a given feed, the default is to assume that both Search and support fo IsAbsoluteLatestVersion is true.  This is a change from the original NuGet.Core assembly, where both of these would default to false if information from the metadata didn't confirm it.

This can be see here:

https://github.com/chocolatey/nuget-chocolatey/blob/a9f040444c705c267363daed59e1bd1e927c2aa9/src/Core/Repositories/DataServiceContextWrapper.cs#L139-L147

And in the usage of these methods:

https://github.com/chocolatey/nuget-chocolatey/blob/a9f040444c705c267363daed59e1bd1e927c2aa9/src/Core/Repositories/DataServicePackageRepository.cs#L168 https://github.com/chocolatey/nuget-chocolatey/blob/a9f040444c705c267363daed59e1bd1e927c2aa9/src/Core/Repositories/DataServicePackageRepository.cs#L229

The decision was taken to perform this override in the catch block, which should hopefully limit the chances for merge conflicts from the upstream repository.

## Motivation and Context

We need the Chocolatey CLI to function in the same way as it did before introducing the new NuGet.Client assemblies.

## Testing

1. Before pulling in these changes, run the following command in Visual Studio while debugging the chocolatey/choco application: ```search --source chocolatey.licensed``` **NOTE:** This will require having a valid license in place in the debug folder
2. This should result in an error stating that the query isn't supported for the given endpoint
3. Pull down the latest changes in this PR, rebuild the NuGet.Client assemblies, and pull them into the chocolatey/choco codebase
4. Re-run the above command, and it should succeed, listing out the packages that are available

### Operating Systems Testing

- Windows 10/11

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added. (Tests has not been updated, as I do not know which are affected by localization and which may have been affected by the update, tests will instead be enabled or added to Chocolatey CLI E2E)
* [ ] All new and existing tests passed? (More tests has been made English only since the last update, unable to verify whether they succeed or not)
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

- #9  
- https://github.com/chocolatey/choco/issues/508
- https://app.clickup.com/t/20540031/PROJ-465