### PR TITLE
(#9) Add slnf with only projects Chocolatey needs

### DIFF
--- a/Chocolatey-NuGet.slnf
+++ b/Chocolatey-NuGet.slnf
@@ -1,0 +1,38 @@
+{
+    "solution": {
+        "path": "NuGet.sln",
+        "projects": [
+            "src\\NuGet.Core\\NuGet.Frameworks\\NuGet.Frameworks.csproj",
+            "src\\NuGet.Core\\NuGet.Commands\\NuGet.Commands.csproj",
+            "src\\NuGet.Core\\NuGet.Protocol\\NuGet.Protocol.csproj",
+            "src\\NuGet.Core\\NuGet.Packaging\\NuGet.Packaging.csproj",
+            "src\\NuGet.Core\\NuGet.Common\\NuGet.Common.csproj",
+            "src\\NuGet.Core\\NuGet.Configuration\\NuGet.Configuration.csproj",
+            "src\\NuGet.Core\\NuGet.PackageManagement\\NuGet.PackageManagement.csproj",
+            "src\\NuGet.Core\\NuGet.DependencyResolver.Core\\NuGet.DependencyResolver.Core.csproj",
+            "src\\NuGet.Core\\NuGet.ProjectModel\\NuGet.ProjectModel.csproj",
+            "src\\NuGet.Core\\NuGet.Resolver\\NuGet.Resolver.csproj",
+            "src\\NuGet.Core\\NuGet.Versioning\\NuGet.Versioning.csproj",
+            "src\\NuGet.Core\\NuGet.Credential\\NuGet.Credentials.csproj",
+            "src\\NuGet.Core\\NuGet.LibraryModel\\NuGet.LibraryModel.csproj",
+            "test\\NuGet.Core.Tests\\NuGet.Commands.Test\\NuGet.Commands.Test.csproj",
+            "test\\NuGet.Core.Tests\\NuGet.Common.Test\\NuGet.Common.Test.csproj",
+            "test\\NuGet.Core.Tests\\NuGet.Configuration.Test\\NuGet.Configuration.Test.csproj",
+            "test\\NuGet.Core.Tests\\NuGet.Credentials.Test\\NuGet.Credentials.Test.csproj",
+            "test\\NuGet.Core.Tests\\NuGet.DependencyResolver.Core.Tests\\NuGet.DependencyResolver.Core.Tests.csproj",
+            "test\\NuGet.Core.Tests\\NuGet.Frameworks.Test\\NuGet.Frameworks.Test.csproj",
+            "test\\NuGet.Core.Tests\\NuGet.LibraryModel.Tests\\NuGet.LibraryModel.Tests.csproj",
+            "test\\NuGet.Core.Tests\\NuGet.PackageManagement.Test\\NuGet.PackageManagement.Test.csproj",
+            "test\\NuGet.Core.Tests\\NuGet.Packaging.Test\\NuGet.Packaging.Test.csproj",
+            "test\\NuGet.Core.Tests\\NuGet.ProjectModel.Test\\NuGet.ProjectModel.Test.csproj",
+            "test\\NuGet.Core.Tests\\NuGet.Protocol.Tests\\NuGet.Protocol.Tests.csproj",
+            "test\\NuGet.Core.Tests\\NuGet.Resolver.Test\\NuGet.Resolver.Test.csproj",
+            "test\\NuGet.Core.Tests\\NuGet.Shared.Tests\\NuGet.Shared.Tests.csproj",
+            "test\\NuGet.Core.Tests\\NuGet.Versioning.Test\\NuGet.Versioning.Test.csproj",
+            "test\\NuGet.Core.FuncTests\\NuGet.Commands.FuncTest\\NuGet.Commands.FuncTest.csproj",
+            "test\\NuGet.Core.FuncTests\\NuGet.Packaging.FuncTest\\NuGet.Packaging.FuncTest.csproj",
+            "test\\NuGet.Core.FuncTests\\NuGet.Protocol.FuncTest\\NuGet.Protocol.FuncTest.csproj",
+            "test\\TestUtilities\\Test.Utility\\Test.Utility.csproj"
+        ]
+    }
+}


### PR DESCRIPTION
## Description Of Changes

Chocolatey only uses a portion of the projects that the NuGet.Client.sln includes.  This commit adds a slnf file with only the projects, and associated test projects, that Chocolatey is using.  This makes it much faster to load and build the projects, as we aren't building projects that we aren't using/editing.

## Motivation and Context

It currently takes _ages_ to build the NuGet.sln

## Testing

1. Open the NuGet.sln in Visual Studio
2. Click the "Switch between solutions and available views" button in the Solution Explorer
3. Select the Chocolatey-NuGet entry
4. Right click on the solution and select Clean Solution
5. Solution should successfully build
6. Right click on the solution and select Rebuild Solution
7. Solution should successfully be re-built
8. The process should be much quicker than building all the projects included within the solution

### Operating Systems Testing

- Windows 10/11

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added. (Tests has not been updated, as I do not know which are affected by localization and which may have been affected by the update, tests will instead be enabled or added to Chocolatey CLI E2E)
* [ ] All new and existing tests passed? (More tests has been made English only since the last update, unable to verify whether they succeed or not)
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

- #9  
- https://app.clickup.com/t/20540031/PROJ-364