### PR TITLE
(#9) New order by for version searching by version

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedListResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedListResource.cs
@@ -44,7 +44,7 @@ namespace NuGet.Protocol
                 {
                     filter = new SearchFilter(includePrerelease: prerelease, filter: null)
                     {
-                        OrderBy = SearchOrderBy.Id,
+                        OrderBy = SearchOrderBy.Version,
                         IncludeDelisted = includeDelisted
                     };
                 }
@@ -78,7 +78,7 @@ namespace NuGet.Protocol
                     filter = new SearchFilter(includePrerelease: prerelease, filter: null)
                     {
                         IncludeDelisted = includeDelisted,
-                        OrderBy = SearchOrderBy.Id
+                        OrderBy = SearchOrderBy.Version
                     };
                 }
                 else

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedQueryBuilder.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedQueryBuilder.cs
@@ -311,6 +311,10 @@ namespace NuGet.Protocol
                     orderBy = string.Format("{0},{1}%20desc", IdProperty, VersionProperty);
                     break;
 
+                case SearchOrderBy.DownloadCountAndVersion:
+                    orderBy = string.Format("{0}%20desc,{1},{2}%20desc", DownloadCountProperty, IdProperty, VersionProperty);
+                    break;
+
                 //////////////////////////////////////////////////////////
                 // End - Chocolatey Specific Modification
                 //////////////////////////////////////////////////////////

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedQueryBuilder.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedQueryBuilder.cs
@@ -38,6 +38,7 @@ namespace NuGet.Protocol
         //////////////////////////////////////////////////////////
 
         private const string DownloadCountProperty = "DownloadCount";
+        private const string VersionProperty = "Version";
 
         //////////////////////////////////////////////////////////
         // End - Chocolatey Specific Modification
@@ -304,6 +305,10 @@ namespace NuGet.Protocol
 
                 case SearchOrderBy.DownloadCount:
                     orderBy = string.Format("{0}%20desc,{1}", DownloadCountProperty, IdProperty);
+                    break;
+
+                case SearchOrderBy.Version:
+                    orderBy = string.Format("{0},{1}%20desc", IdProperty, VersionProperty);
                     break;
 
                 //////////////////////////////////////////////////////////

--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalPackageListResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalPackageListResource.cs
@@ -131,6 +131,7 @@ namespace NuGet.Protocol
                             goto default;
 
                         case SearchOrderBy.Version:
+                        case SearchOrderBy.DownloadCountAndVersion:
                             _currentEnumerator = results.OrderBy(p => p.Identity.Id).ThenByDescending(p => p.Identity.Version).GetEnumerator();
                             break;
 

--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalPackageListResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalPackageListResource.cs
@@ -130,6 +130,10 @@ namespace NuGet.Protocol
                             // Local packages do not have downloads available
                             goto default;
 
+                        case SearchOrderBy.Version:
+                            _currentEnumerator = results.OrderBy(p => p.Identity.Id).ThenByDescending(p => p.Identity.Version).GetEnumerator();
+                            break;
+
                         //////////////////////////////////////////////////////////
                         // End - Chocolatey Specific Modification
                         //////////////////////////////////////////////////////////

--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalPackageListResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalPackageListResource.cs
@@ -31,7 +31,7 @@ namespace NuGet.Protocol
             {
                 filter = new SearchFilter(includePrerelease: prerelease, filter: null)
                 {
-                    OrderBy = SearchOrderBy.Id,
+                    OrderBy = SearchOrderBy.Version,
                     IncludeDelisted = includeDelisted
                 };
             }

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -122,6 +122,7 @@ NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetada
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.VersionDownloadCount.get -> int?
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.VersionDownloadCount.set -> void
 NuGet.Protocol.Core.Types.SearchOrderBy.DownloadCount = 1 -> NuGet.Protocol.Core.Types.SearchOrderBy
+NuGet.Protocol.Core.Types.SearchOrderBy.Version = 2 -> NuGet.Protocol.Core.Types.SearchOrderBy
 NuGet.Protocol.HttpSourceResource.OverrideHttpSource(NuGet.Protocol.IHttpSource source) -> void
 NuGet.Protocol.IHttpSource
 NuGet.Protocol.IHttpSource.GetAsync<T>(NuGet.Protocol.HttpSourceCachedRequest request, System.Func<NuGet.Protocol.HttpSourceResult, System.Threading.Tasks.Task<T>> processAsync, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -122,6 +122,7 @@ NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetada
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.VersionDownloadCount.get -> int?
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.VersionDownloadCount.set -> void
 NuGet.Protocol.Core.Types.SearchOrderBy.DownloadCount = 1 -> NuGet.Protocol.Core.Types.SearchOrderBy
+NuGet.Protocol.Core.Types.SearchOrderBy.DownloadCountAndVersion = 3 -> NuGet.Protocol.Core.Types.SearchOrderBy
 NuGet.Protocol.Core.Types.SearchOrderBy.Version = 2 -> NuGet.Protocol.Core.Types.SearchOrderBy
 NuGet.Protocol.HttpSourceResource.OverrideHttpSource(NuGet.Protocol.IHttpSource source) -> void
 NuGet.Protocol.IHttpSource

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -122,6 +122,7 @@ NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetada
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.VersionDownloadCount.get -> int?
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.VersionDownloadCount.set -> void
 NuGet.Protocol.Core.Types.SearchOrderBy.DownloadCount = 1 -> NuGet.Protocol.Core.Types.SearchOrderBy
+NuGet.Protocol.Core.Types.SearchOrderBy.Version = 2 -> NuGet.Protocol.Core.Types.SearchOrderBy
 NuGet.Protocol.HttpSourceResource.OverrideHttpSource(NuGet.Protocol.IHttpSource source) -> void
 NuGet.Protocol.IHttpSource
 NuGet.Protocol.IHttpSource.GetAsync<T>(NuGet.Protocol.HttpSourceCachedRequest request, System.Func<NuGet.Protocol.HttpSourceResult, System.Threading.Tasks.Task<T>> processAsync, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -122,6 +122,7 @@ NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetada
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.VersionDownloadCount.get -> int?
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.VersionDownloadCount.set -> void
 NuGet.Protocol.Core.Types.SearchOrderBy.DownloadCount = 1 -> NuGet.Protocol.Core.Types.SearchOrderBy
+NuGet.Protocol.Core.Types.SearchOrderBy.DownloadCountAndVersion = 3 -> NuGet.Protocol.Core.Types.SearchOrderBy
 NuGet.Protocol.Core.Types.SearchOrderBy.Version = 2 -> NuGet.Protocol.Core.Types.SearchOrderBy
 NuGet.Protocol.HttpSourceResource.OverrideHttpSource(NuGet.Protocol.IHttpSource source) -> void
 NuGet.Protocol.IHttpSource

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -122,6 +122,7 @@ NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetada
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.VersionDownloadCount.get -> int?
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.VersionDownloadCount.set -> void
 NuGet.Protocol.Core.Types.SearchOrderBy.DownloadCount = 1 -> NuGet.Protocol.Core.Types.SearchOrderBy
+NuGet.Protocol.Core.Types.SearchOrderBy.Version = 2 -> NuGet.Protocol.Core.Types.SearchOrderBy
 NuGet.Protocol.HttpSourceResource.OverrideHttpSource(NuGet.Protocol.IHttpSource source) -> void
 NuGet.Protocol.IHttpSource
 NuGet.Protocol.IHttpSource.GetAsync<T>(NuGet.Protocol.HttpSourceCachedRequest request, System.Func<NuGet.Protocol.HttpSourceResult, System.Threading.Tasks.Task<T>> processAsync, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -122,6 +122,7 @@ NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetada
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.VersionDownloadCount.get -> int?
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.VersionDownloadCount.set -> void
 NuGet.Protocol.Core.Types.SearchOrderBy.DownloadCount = 1 -> NuGet.Protocol.Core.Types.SearchOrderBy
+NuGet.Protocol.Core.Types.SearchOrderBy.DownloadCountAndVersion = 3 -> NuGet.Protocol.Core.Types.SearchOrderBy
 NuGet.Protocol.Core.Types.SearchOrderBy.Version = 2 -> NuGet.Protocol.Core.Types.SearchOrderBy
 NuGet.Protocol.HttpSourceResource.OverrideHttpSource(NuGet.Protocol.IHttpSource source) -> void
 NuGet.Protocol.IHttpSource

--- a/src/NuGet.Core/NuGet.Protocol/SearchOrderBy.cs
+++ b/src/NuGet.Core/NuGet.Protocol/SearchOrderBy.cs
@@ -22,7 +22,12 @@ namespace NuGet.Protocol.Core.Types
         /// <summary>
         /// Order the resulting packages grouped by the version number
         /// </summary>
-        Version
+        Version,
+
+        /// <summary>
+        /// Order the resulting packages by number of downloads, and also group by the version number
+        /// </summary>
+        DownloadCountAndVersion
 
         //////////////////////////////////////////////////////////
         // End - Chocolatey Specific Modification

--- a/src/NuGet.Core/NuGet.Protocol/SearchOrderBy.cs
+++ b/src/NuGet.Core/NuGet.Protocol/SearchOrderBy.cs
@@ -17,7 +17,12 @@ namespace NuGet.Protocol.Core.Types
         /// <summary>
         /// Order the resulting packages by number of donwnloads.
         /// </summary>
-        DownloadCount
+        DownloadCount,
+
+        /// <summary>
+        /// Order the resulting packages grouped by the version number
+        /// </summary>
+        Version
 
         //////////////////////////////////////////////////////////
         // End - Chocolatey Specific Modification

--- a/src/NuGet.Core/NuGet.Protocol/SearchOrderBy.cs
+++ b/src/NuGet.Core/NuGet.Protocol/SearchOrderBy.cs
@@ -15,7 +15,7 @@ namespace NuGet.Protocol.Core.Types
         //////////////////////////////////////////////////////////
 
         /// <summary>
-        /// Order the resulting packages by number of donwnloads.
+        /// Order the resulting packages by number of downloads.
         /// </summary>
         DownloadCount,
 


### PR DESCRIPTION
## Description Of Changes

This commit adds the Version property to SearchOrderBy, which can then be used within chocolatey/choco codebase, when required.

## Motivation and Context

When searching by version number in the 1.x version of Chocolatey, an additional orderby of "Id, Version desc" is included.  In order to maintain backwards compatibility, we need to also include this orderby in the new NuGet.Client based implementation.

This work is similar to the work that was done in this commit, where the DownloadCount orderby was added:

https://github.com/chocolatey/NuGet.Client/pull/25/commits/d28424ed2d2bf75afe77d775231c50ccc4a78c66

## Testing

1. Check out this PR, and build the NuGet.Client solution
2. Check out the associated PR into chocolatey/choco - https://github.com/chocolatey/choco/pull/3044
4. Pull the updated NuGet.Client assemblies into the chocolatey/choco project
5. Open Fiddler
6. Run the following command `search windirstat --version 1.1.2 --proxy http://localhost:8888`
7. Look at the captured requests in Fiddler, and ensure that the generated query includes the following `$orderby=Id,Version%20desc`

### Operating Systems Testing

- Windows 10/11

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added. (Tests has not been updated, as I do not know which are affected by localization and which may have been affected by the update, tests will instead be enabled or added to Chocolatey CLI E2E)
* [x] All new and existing tests passed? (More tests has been made English only since the last update, unable to verify whether they succeed or not)
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issues

- #9  
- https://app.clickup.com/t/20540031/PROJ-511
