### PR TITLE
(#9) Alter filter construction for prereleases

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/IV2FeedParser.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/IV2FeedParser.cs
@@ -39,6 +39,14 @@ namespace NuGet.Protocol
         // Start - Chocolatey Specific Modification
         //////////////////////////////////////////////////////////
 
+        Task<IReadOnlyList<V2FeedPackageInfo>> FindPackagesByIdAsync(
+            string id,
+            bool includeUnlisted,
+            bool includePrerelease,
+            SourceCacheContext sourceCacheContext,
+            ILogger log,
+            CancellationToken token);
+
         Task<IReadOnlyList<V2FeedPackageInfo>> GetPackageVersionsAsync(
             string id,
             bool includeUnlisted,

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -146,6 +146,7 @@ NuGet.Protocol.IHttpSource.ProcessStreamAsync<T>(NuGet.Protocol.HttpSourceReques
 NuGet.Protocol.IHttpSource.ProcessStreamAsync<T>(NuGet.Protocol.HttpSourceRequest request, System.Func<System.IO.Stream, System.Threading.Tasks.Task<T>> processAsync, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>
 NuGet.Protocol.IHttpSource.RetryHandler.get -> NuGet.Protocol.IHttpRetryHandler
 NuGet.Protocol.IHttpSource.RetryHandler.set -> void
+NuGet.Protocol.IV2FeedParser.FindPackagesByIdAsync(string id, bool includeUnlisted, bool includePrerelease, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<NuGet.Protocol.V2FeedPackageInfo>>
 NuGet.Protocol.IV2FeedParser.GetPackageVersionsAsync(string id, bool includeUnlisted, bool includePreRelease, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<NuGet.Protocol.V2FeedPackageInfo>>
 NuGet.Protocol.LocalPackageSearchMetadata.BugTrackerUrl.get -> System.Uri
 NuGet.Protocol.LocalPackageSearchMetadata.DocsUrl.get -> System.Uri

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -146,6 +146,7 @@ NuGet.Protocol.IHttpSource.ProcessStreamAsync<T>(NuGet.Protocol.HttpSourceReques
 NuGet.Protocol.IHttpSource.ProcessStreamAsync<T>(NuGet.Protocol.HttpSourceRequest request, System.Func<System.IO.Stream, System.Threading.Tasks.Task<T>> processAsync, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>
 NuGet.Protocol.IHttpSource.RetryHandler.get -> NuGet.Protocol.IHttpRetryHandler
 NuGet.Protocol.IHttpSource.RetryHandler.set -> void
+NuGet.Protocol.IV2FeedParser.FindPackagesByIdAsync(string id, bool includeUnlisted, bool includePrerelease, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<NuGet.Protocol.V2FeedPackageInfo>>
 NuGet.Protocol.IV2FeedParser.GetPackageVersionsAsync(string id, bool includeUnlisted, bool includePreRelease, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<NuGet.Protocol.V2FeedPackageInfo>>
 NuGet.Protocol.LocalPackageSearchMetadata.BugTrackerUrl.get -> System.Uri
 NuGet.Protocol.LocalPackageSearchMetadata.DocsUrl.get -> System.Uri

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -145,6 +145,7 @@ NuGet.Protocol.IHttpSource.ProcessStreamAsync<T>(NuGet.Protocol.HttpSourceReques
 NuGet.Protocol.IHttpSource.ProcessStreamAsync<T>(NuGet.Protocol.HttpSourceRequest request, System.Func<System.IO.Stream, System.Threading.Tasks.Task<T>> processAsync, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>
 NuGet.Protocol.IHttpSource.RetryHandler.get -> NuGet.Protocol.IHttpRetryHandler
 NuGet.Protocol.IHttpSource.RetryHandler.set -> void
+NuGet.Protocol.IV2FeedParser.FindPackagesByIdAsync(string id, bool includeUnlisted, bool includePrerelease, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<NuGet.Protocol.V2FeedPackageInfo>>
 NuGet.Protocol.IV2FeedParser.GetPackageVersionsAsync(string id, bool includeUnlisted, bool includePreRelease, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<NuGet.Protocol.V2FeedPackageInfo>>
 NuGet.Protocol.LocalPackageSearchMetadata.BugTrackerUrl.get -> System.Uri
 NuGet.Protocol.LocalPackageSearchMetadata.DocsUrl.get -> System.Uri


### PR DESCRIPTION
## Description Of Changes

When the prerelease option is included in the outgoing query, a decision is made about including either IsLatestVersion is IsAbsoluteLatestVersion in the query.  However, in the case where preelease is true and the feed being queried doesn't support IsAbsoluteLatestVersion, the IsLatestVersion is included in the query.

This is deemed as wrong, since it is the exact opposite of what is being asked for.

This commit addresses this issue specifically by only including IsLatestVersion when explicitly not asking for prerelease.  We believe that this will prevent confusion when folks are using Chocolatey.

## Motivation and Context

To prevent confusion of users.

## Testing

1. Check out this PR, and build the NuGet.Client solution
2. Pull the changes into Chocolatey source code
3. Open fiddler on your machine
4. Ensure that you have a valid license file in place in debug version of Chocolatey
5. Run the following command `search chocolatey-agent --pre --source=chocolatey.licensed --proxy=http://localhost:8888`
6. Verify that in the emitted query, that there is no mention of IsLatestVersion
7. Run the following command `info chocolatey-agent --pre --proxy=http://localhost:8888`
8. Make sure that no mention of IsAbsoluteLatestVersion is included in the outgoing query to licensed feed
9. Run the following command `install chocolatey-agent --pre --proxy=http://localhost:8888`
10. Make sure that no mention of IsAbsoluteLatestVersion is included in the outgoing query to licensed feed

### Operating Systems Testing

- Windows 10/11

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added. (Tests has not been updated, as I do not know which are affected by localization and which may have been affected by the update, tests will instead be enabled or added to Chocolatey CLI E2E)
* [x] All new and existing tests passed? (More tests has been made English only since the last update, unable to verify whether they succeed or not)
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issues

- #9  
- https://app.clickup.com/t/20540031/PROJ-520