### PR TITLE
(#9) Optimize queries used for command line options

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -125,8 +125,14 @@ NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetada
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReleaseNotes.set -> void
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.VersionDownloadCount.get -> int?
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.VersionDownloadCount.set -> void
+NuGet.Protocol.Core.Types.SearchFilter.ByIdOnly.get -> bool
+NuGet.Protocol.Core.Types.SearchFilter.ByIdOnly.set -> void
+NuGet.Protocol.Core.Types.SearchFilter.ByTagOnly.get -> bool
+NuGet.Protocol.Core.Types.SearchFilter.ByTagOnly.set -> void
 NuGet.Protocol.Core.Types.SearchFilter.ExactPackageId.get -> bool
 NuGet.Protocol.Core.Types.SearchFilter.ExactPackageId.set -> void
+NuGet.Protocol.Core.Types.SearchFilter.IdStartsWith.get -> bool
+NuGet.Protocol.Core.Types.SearchFilter.IdStartsWith.set -> void
 NuGet.Protocol.Core.Types.SearchOrderBy.DownloadCount = 1 -> NuGet.Protocol.Core.Types.SearchOrderBy
 NuGet.Protocol.Core.Types.SearchOrderBy.DownloadCountAndVersion = 3 -> NuGet.Protocol.Core.Types.SearchOrderBy
 NuGet.Protocol.Core.Types.SearchOrderBy.Version = 2 -> NuGet.Protocol.Core.Types.SearchOrderBy

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netcoreapp5.0/PublicAPI.Unshipped.txt
@@ -125,8 +125,14 @@ NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetada
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReleaseNotes.set -> void
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.VersionDownloadCount.get -> int?
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.VersionDownloadCount.set -> void
+NuGet.Protocol.Core.Types.SearchFilter.ByIdOnly.get -> bool
+NuGet.Protocol.Core.Types.SearchFilter.ByIdOnly.set -> void
+NuGet.Protocol.Core.Types.SearchFilter.ByTagOnly.get -> bool
+NuGet.Protocol.Core.Types.SearchFilter.ByTagOnly.set -> void
 NuGet.Protocol.Core.Types.SearchFilter.ExactPackageId.get -> bool
 NuGet.Protocol.Core.Types.SearchFilter.ExactPackageId.set -> void
+NuGet.Protocol.Core.Types.SearchFilter.IdStartsWith.get -> bool
+NuGet.Protocol.Core.Types.SearchFilter.IdStartsWith.set -> void
 NuGet.Protocol.Core.Types.SearchOrderBy.DownloadCount = 1 -> NuGet.Protocol.Core.Types.SearchOrderBy
 NuGet.Protocol.Core.Types.SearchOrderBy.DownloadCountAndVersion = 3 -> NuGet.Protocol.Core.Types.SearchOrderBy
 NuGet.Protocol.Core.Types.SearchOrderBy.Version = 2 -> NuGet.Protocol.Core.Types.SearchOrderBy

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -124,8 +124,14 @@ NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetada
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReleaseNotes.set -> void
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.VersionDownloadCount.get -> int?
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.VersionDownloadCount.set -> void
+NuGet.Protocol.Core.Types.SearchFilter.ByIdOnly.get -> bool
+NuGet.Protocol.Core.Types.SearchFilter.ByIdOnly.set -> void
+NuGet.Protocol.Core.Types.SearchFilter.ByTagOnly.get -> bool
+NuGet.Protocol.Core.Types.SearchFilter.ByTagOnly.set -> void
 NuGet.Protocol.Core.Types.SearchFilter.ExactPackageId.get -> bool
 NuGet.Protocol.Core.Types.SearchFilter.ExactPackageId.set -> void
+NuGet.Protocol.Core.Types.SearchFilter.IdStartsWith.get -> bool
+NuGet.Protocol.Core.Types.SearchFilter.IdStartsWith.set -> void
 NuGet.Protocol.Core.Types.SearchOrderBy.DownloadCount = 1 -> NuGet.Protocol.Core.Types.SearchOrderBy
 NuGet.Protocol.Core.Types.SearchOrderBy.DownloadCountAndVersion = 3 -> NuGet.Protocol.Core.Types.SearchOrderBy
 NuGet.Protocol.Core.Types.SearchOrderBy.Version = 2 -> NuGet.Protocol.Core.Types.SearchOrderBy

--- a/src/NuGet.Core/NuGet.Protocol/SearchFilter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/SearchFilter.cs
@@ -63,6 +63,12 @@ namespace NuGet.Protocol.Core.Types
         /// </summary>
         public bool ExactPackageId { get; set; } = false;
 
+        public bool ByIdOnly { get; set; } = false;
+
+        public bool ByTagOnly { get; set; } = false;
+
+        public bool IdStartsWith { get; set; } = false;
+
         //////////////////////////////////////////////////////////
         // End - Chocolatey Specific Modification
         //////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description Of Changes

This commit adds this into the queries (it will require an additionl
change into the chocolatey/choco codebase to make use of it), and makes
the resulting queries similar to what is sent out in 1.x of choco.exe.

## Motivation and Context

In order to make the most optimal oData queries, we need to ensure that
we are only asking for the information that meets our needs.  For
example, when using the command line options for --by-id-only, or
--by-tag-only, or --id-starts-with, we should add this information into
the oData query that is sent out.

## Testing

1. Check out this PR, and build the NuGet.Client solution
2. Check out the accompanying [PR](https://github.com/chocolatey/choco/pull/3066) for chocolatey/choco
3. Build and pull the changes for NuGet.Client into Chocolatey source code
4. Open fiddler on your machine
5. Run the following command `search chocolatey --by-id-only --proxy=http://localhost:8888`
6. Verify that an oData filter is added to the outgoing query to substring on the ID property
7. Run the following command `search chocolatey --by-tag-only --proxy=http://localhost:8888`
8. Verify that an oData filter is added to the outgoing query to substring on the Tag property
9. Run the following command `search chocolatey --id-starts-with --proxy=http://localhost:8888`
10. Verify that an oData filter is added to the outgoing query to startswith on the ID property
11. Run the following command `search chocolatey --by-id-only --by-tag-only --proxy=http://localhost:8888`
12. Verify that an oData filter is added to the outgoing query to substring on both the ID and Tag property
13. Run the following command `search chocolatey --by-id-only -by-tag-only --id-starts-with --proxy=http://localhost:8888`
14. Verify that an oData filter is added to the outgoing query to substring on Tag property and the startswith - NOTE the omission of the substring on the ID is due to only one of the mutually exclusive clauses being used here.

### Operating Systems Testing

- Windows 10/11

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added. (Tests has not been updated, as I do not know which are affected by localization and which may have been affected by the update, tests will instead be enabled or added to Chocolatey CLI E2E)
* [x] All new and existing tests passed? (More tests has been made English only since the last update, unable to verify whether they succeed or not)
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issues

- #9  
- https://app.clickup.com/t/20540031/PROJ-510