### PR TITLE
(#38) Allow getting the system proxy if no proxy was overridden

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/Proxy/ProxyCache.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Proxy/ProxyCache.cs
@@ -64,7 +64,22 @@ namespace NuGet.Configuration
 
             if (_isProxyOverridden)
             {
-                return _overrideProxy;
+                if (_overrideProxy != null)
+                {
+                    return _overrideProxy;
+                }
+
+                // This is explicitly a copy of the below code so that Chocolatey can get the System proxy settings without the NuGet User configured settings.
+#if !IS_CORECLR
+                if (IsSystemProxySet(sourceUri))
+                {
+                    var systemProxy = GetSystemProxy(sourceUri);
+                    TryAddProxyCredentialsToCache(systemProxy);
+                    systemProxy.Credentials = this;
+                    return systemProxy;
+                }
+#endif
+                return null;
             }
 
             //////////////////////////////////////////////////////////

--- a/src/NuGet.Core/NuGet.Configuration/Proxy/ProxyCache.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Proxy/ProxyCache.cs
@@ -83,7 +83,7 @@ namespace NuGet.Configuration
             }
 
             //////////////////////////////////////////////////////////
-            // Start - Chocolatey Specific Modification
+            // End - Chocolatey Specific Modification
             //////////////////////////////////////////////////////////
 
             // Check if the user has configured proxy details in settings or in the environment.


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: #38 

Regression? Last working version:

## Description

Previously, Chocolatey would pass a fresh WebProxy in as an override. Unfortunately this object doesn't know anything about the system proxy. Instead of re-inventing the wheel on the Chocolatey side, we should pass in a null proxy, then let NuGet.Client pull the system proxy configuration if it exists.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  - [x] Test exception
  - **OR**
  - [ ] N/A <!-- Infrastructure, documentation etc. -->

I have no idea how to add automated tests to NuGet.Client. The manual testing I have done is:

1. Build the NuGet.Client code and bring it into `chocolatey/choco`. (PR for changes needed there to be added)
2. Set a breakpoint on `ProxyCache.GetProxy()`.
3. Configure the System Proxy to have a dummy value for the proxy.
4. Debug a `choco search chocolatey` execution.
5. Ensure that the process flow passes through the correct proxy value.

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
