### PR TITLE
(#42) Attempt to fix http caching issue when running as non-admin user

### DIFF
--- a/src/NuGet.Core/NuGet.Common/ConcurrencyUtilities.cs
+++ b/src/NuGet.Core/NuGet.Common/ConcurrencyUtilities.cs
@@ -27,6 +27,34 @@ namespace NuGet.Common
         private static bool UseDeleteOnClose = RuntimeEnvironmentHelper.IsWindows ||
                                                Environment.GetEnvironmentVariable("NUGET_ConcurrencyUtils_DeleteOnClose") == "1"; // opt-in.
 
+        //////////////////////////////////////////////////////////
+        // Start - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
+
+        public async static Task<T> ExecuteWithFileLockedAsync<T>(string filePath,
+            Func<CancellationToken, Task<T>> action,
+            CancellationToken token,
+            string lockFileDirectoryPath)
+        {
+            var originalBasePath = BasePath;
+            BasePath = lockFileDirectoryPath;
+
+            try
+            {
+                var result = await ExecuteWithFileLockedAsync(filePath, action, token);
+
+                return result;
+            }
+            finally
+            {
+                BasePath = originalBasePath;
+            }
+        }
+
+        //////////////////////////////////////////////////////////
+        // End - Chocolatey Specific Modification
+        //////////////////////////////////////////////////////////
+
         public async static Task<T> ExecuteWithFileLockedAsync<T>(string filePath,
             Func<CancellationToken, Task<T>> action,
             CancellationToken token)
@@ -231,6 +259,19 @@ namespace NuGet.Common
 
                 return _basePath;
             }
+
+            //////////////////////////////////////////////////////////
+            // Start - Chocolatey Specific Modification
+            //////////////////////////////////////////////////////////
+
+            set
+            {
+                _basePath = value;
+            }
+
+            //////////////////////////////////////////////////////////
+            // End - Chocolatey Specific Modification
+            //////////////////////////////////////////////////////////
         }
 
         private static string FileLockPath(string filePath)

--- a/src/NuGet.Core/NuGet.Common/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+static NuGet.Common.ConcurrencyUtilities.ExecuteWithFileLockedAsync<T>(string filePath, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> action, System.Threading.CancellationToken token, string lockFileDirectoryPath) -> System.Threading.Tasks.Task<T>

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
@@ -101,6 +101,13 @@ namespace NuGet.Protocol
                 cacheResult.CacheFile = GetHashedCacheFileName(cacheResult.CacheFile);
             }
 
+            var lockFileDirectoryPath = Path.Combine(new FileInfo(HttpCacheDirectory).Directory.FullName, "ChocolateyHttpCache", ".locks");
+
+            if (HttpCacheDirectory.IndexOf(".chocolatey", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                lockFileDirectoryPath = Path.Combine(new FileInfo(HttpCacheDirectory).Directory.FullName, "http-cache", ".locks");
+            }
+
             //////////////////////////////////////////////////////////
             // End - Chocolatey Specific Modification
             //////////////////////////////////////////////////////////
@@ -216,7 +223,15 @@ namespace NuGet.Protocol
                         }
                     }
                 },
-                token: token);
+                token: token,
+                //////////////////////////////////////////////////////////
+                // Start - Chocolatey Specific Modification
+                //////////////////////////////////////////////////////////
+                lockFileDirectoryPath: lockFileDirectoryPath
+                //////////////////////////////////////////////////////////
+                // End - Chocolatey Specific Modification
+                //////////////////////////////////////////////////////////
+                );
         }
 
         public Task<T> ProcessStreamAsync<T>(


### PR DESCRIPTION
## Description Of Changes

This changes in this PR create a new folder to store the lock files that are used when HTTP Cache Queries are persisted to disk.  By taking control of this, rather than having this location controlled by the `cacheLocation` value in the chocolatey.config file, it means that we have greater control over _where_ these files end up, and more importantly, can ensure that the current user has permission to create these files.

As a result of these changes, the following folder will now exist on disk:

* C:\ProgramData\ChocolateyHttpCache
* C:\ProgramData\ChocolateyHttpCacheLocks
* C:\Users\<name-of-user>\.chocolatey\http-cache
* C:\Users\<name-of-user>\.chocolatey\http-cache-locks

NOTE: At some point, in a later scope of work, we may want to consolidate the `Chocolatey`, `Chocolatey GUI`, `ChocolateyHttpCache`, and `ChocolateyHttpCacheLocks`, into one place, rather than having four different locations, but this is regarded as a larger scope of work than is required just now.

A new overload for the `ExecuteWithFileLockedAsync` method has been introduced, which allows for setting of the `BasePath` variable, which controls where the lock file is created.  This means that we can directly set this from the HttpSource class, while leaving the other lock file logic in place.  Within this overload, we ensure to reset the BasePath back to null, so that the next call into this method will re-establish what this should be.

## Motivation and Context

We need to be able to run queries, and store the results of the query on disk, in a location that the current user has access to.  When we change the `cacheLocation` of the Chocolatey CLI configuration, the location of the lock file used when saving the HTTP query results shouldn't be impacted.

## Testing

1. Build Chocolatey.NuGet.Client assemblies from this PR
1. Run the `update-client` script to pull latest Chocolatey.NuGet.Client assemblies into Chocolatey CLI
2. Build Chocolatey CLI
3. Install Chocolatey CLI nupkg on a machine
1. Ran `choco config set --name="'cacheLocation'" --value="'c:\programdata\chocolatey\choco-cache'"` 
1. Create a new non-admin user on the computer
1. Logged out as administrator and logged in as the non-admin user
1. Run command `choco outdated`

### Operating Systems Testing

Win10

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

- Fixes #42 