### PR TITLE
(#44) Use parent directory for lock files location

### DIFF
--- a/src/NuGet.Core/NuGet.Common/PathUtil/FileUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/FileUtility.cs
@@ -37,6 +37,16 @@ namespace NuGet.Common
                 throw new ArgumentNullException(nameof(filePath));
             }
 
+            //////////////////////////////////////////////////////////
+            // Start - Chocolatey Specific Modification
+            //////////////////////////////////////////////////////////
+
+            var lockDirectory = Path.GetDirectoryName(filePath) ?? Environment.CurrentDirectory;
+
+            //////////////////////////////////////////////////////////
+            // End - Chocolatey Specific Modification
+            //////////////////////////////////////////////////////////
+
             await ConcurrencyUtilities.ExecuteWithFileLockedAsync(filePath,
                 lockedToken =>
                 {
@@ -45,7 +55,14 @@ namespace NuGet.Common
                     return Task.FromResult(0);
                 },
                 // Do not allow this to be cancelled
-                CancellationToken.None);
+                CancellationToken.None,
+                //////////////////////////////////////////////////////////
+                // Start - Chocolatey Specific Modification
+                //////////////////////////////////////////////////////////
+                lockDirectory);
+                //////////////////////////////////////////////////////////
+                // End- Chocolatey Specific Modification
+                //////////////////////////////////////////////////////////
         }
 
         /// <summary>
@@ -65,6 +82,16 @@ namespace NuGet.Common
                 throw new ArgumentNullException(nameof(destFilePath));
             }
 
+            //////////////////////////////////////////////////////////
+            // Start - Chocolatey Specific Modification
+            //////////////////////////////////////////////////////////
+
+            var lockDirectory = Path.GetDirectoryName(destFilePath) ?? Environment.CurrentDirectory;
+
+            //////////////////////////////////////////////////////////
+            // End - Chocolatey Specific Modification
+            //////////////////////////////////////////////////////////
+
             await ConcurrencyUtilities.ExecuteWithFileLockedAsync(destFilePath,
                 lockedToken =>
                 {
@@ -73,7 +100,14 @@ namespace NuGet.Common
                     return Task.FromResult(0);
                 },
                 // Do not allow this to be cancelled
-                CancellationToken.None);
+                CancellationToken.None,
+                //////////////////////////////////////////////////////////
+                // Start - Chocolatey Specific Modification
+                //////////////////////////////////////////////////////////
+                lockDirectory);
+                //////////////////////////////////////////////////////////
+                // End- Chocolatey Specific Modification
+                //////////////////////////////////////////////////////////
         }
 
         /// <summary>
@@ -240,7 +274,7 @@ namespace NuGet.Common
                     Sleep(100);
                 }
             }
-            // This will never reached, but the compiler can't detect that 
+            // This will never reached, but the compiler can't detect that
             return default(T);
         }
 
@@ -262,7 +296,7 @@ namespace NuGet.Common
                     Sleep(100);
                 }
             }
-            // This will never reached, but the compiler can't detect that 
+            // This will never reached, but the compiler can't detect that
             return default(T);
         }
 

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/FolderNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/FolderNuGetProject.cs
@@ -146,6 +146,16 @@ namespace NuGet.ProjectManagement
 
             var packageDirectory = PackagePathResolver.GetInstallPath(packageIdentity);
 
+            //////////////////////////////////////////////////////////
+            // Start - Chocolatey Specific Modification
+            //////////////////////////////////////////////////////////
+
+            var lockDirectory = Path.GetDirectoryName(packageDirectory) ?? Environment.CurrentDirectory;
+
+            //////////////////////////////////////////////////////////
+            // End - Chocolatey Specific Modification
+            //////////////////////////////////////////////////////////
+
             return ConcurrencyUtilities.ExecuteWithFileLockedAsync(
                 packageDirectory,
                 action: async cancellationToken =>
@@ -230,7 +240,14 @@ namespace NuGet.ProjectManagement
 
                     return true;
                 },
-                token: token);
+                token: token,
+                //////////////////////////////////////////////////////////
+                // Start - Chocolatey Specific Modification
+                //////////////////////////////////////////////////////////
+                lockDirectory);
+                //////////////////////////////////////////////////////////
+                // End- Chocolatey Specific Modification
+                //////////////////////////////////////////////////////////
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
@@ -385,6 +385,16 @@ namespace NuGet.Packaging
                 logger.LogVerbose(
                     $"Acquiring lock for the installation of {packageIdentity.Id} {packageIdentity.Version}");
 
+                //////////////////////////////////////////////////////////
+                // Start - Chocolatey Specific Modification
+                //////////////////////////////////////////////////////////
+
+                var lockDirectory = Path.GetDirectoryName(targetNupkg) ?? Environment.CurrentDirectory;
+
+                //////////////////////////////////////////////////////////
+                // End - Chocolatey Specific Modification
+                //////////////////////////////////////////////////////////
+
                 // Acquire the lock on a nukpg before we extract it to prevent the race condition when multiple
                 // processes are extracting to the same destination simultaneously
                 return await ConcurrencyUtilities.ExecuteWithFileLockedAsync(targetNupkg,
@@ -563,7 +573,14 @@ namespace NuGet.Packaging
                             return false;
                         }
                     },
-                    token: token);
+                    token: token,
+                    //////////////////////////////////////////////////////////
+                    // Start - Chocolatey Specific Modification
+                    //////////////////////////////////////////////////////////
+                    lockDirectory);
+                    //////////////////////////////////////////////////////////
+                    // End- Chocolatey Specific Modification
+                    //////////////////////////////////////////////////////////
             }
         }
 
@@ -623,6 +640,16 @@ namespace NuGet.Packaging
 
                 logger.LogVerbose(
                     $"Acquiring lock for the installation of {packageIdentity.Id} {packageIdentity.Version}");
+
+                //////////////////////////////////////////////////////////
+                // Start - Chocolatey Specific Modification
+                //////////////////////////////////////////////////////////
+
+                var lockDirectory = Path.GetDirectoryName(targetNupkg) ?? Environment.CurrentDirectory;
+
+                //////////////////////////////////////////////////////////
+                // End - Chocolatey Specific Modification
+                //////////////////////////////////////////////////////////
 
                 // Acquire the lock on a nukpg before we extract it to prevent the race condition when multiple
                 // processes are extracting to the same destination simultaneously
@@ -830,7 +857,14 @@ namespace NuGet.Packaging
                             return false;
                         }
                     },
-                    token: token);
+                    token: token,
+                    //////////////////////////////////////////////////////////
+                    // Start - Chocolatey Specific Modification
+                    //////////////////////////////////////////////////////////
+                    lockDirectory);
+                    //////////////////////////////////////////////////////////
+                    // End- Chocolatey Specific Modification
+                    //////////////////////////////////////////////////////////
             }
         }
 

--- a/src/NuGet.Core/NuGet.Protocol/Utility/FindPackagesByIdNupkgDownloader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/FindPackagesByIdNupkgDownloader.cs
@@ -393,6 +393,16 @@ namespace NuGet.Protocol
                 return false;
             }
 
+            //////////////////////////////////////////////////////////
+            // Start - Chocolatey Specific Modification
+            //////////////////////////////////////////////////////////
+
+            var lockDirectory = Path.GetDirectoryName(cacheEntry.CacheFile) ?? Environment.CurrentDirectory;
+
+            //////////////////////////////////////////////////////////
+            // End - Chocolatey Specific Modification
+            //////////////////////////////////////////////////////////
+
             // Acquire the lock on a file before we open it to prevent this process
             // from opening a file deleted by another HTTP request.
             using (var cacheStream = await ConcurrencyUtilities.ExecuteWithFileLockedAsync(
@@ -406,7 +416,14 @@ namespace NuGet.Protocol
                         FileShare.ReadWrite | FileShare.Delete,
                         StreamExtensions.BufferSize));
                 },
-                token))
+                token,
+                //////////////////////////////////////////////////////////
+                // Start - Chocolatey Specific Modification
+                //////////////////////////////////////////////////////////
+                lockDirectory))
+                //////////////////////////////////////////////////////////
+                // End- Chocolatey Specific Modification
+                //////////////////////////////////////////////////////////
             {
                 await processStreamAsync(cacheStream);
 


### PR DESCRIPTION
## Bug

Fixes: #44

Regression? Last working version: N/A

## Description

These changes where lock files are created. Instead of having a
single location when creating lock files which may be a location
that can not be written to in some contextes, this commit changes
the behavior to use the same location that the that is modified,
removed or added is expected to be.

This allows us to continue overriding the %TEMP% variable in
Chocolatey CLI, while still allowing users of non-elevated commands
to function as expected, like `choco download` when the cache location
has been set to an admin only location.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked issue.
- [x] Described changes