### PR TITLE
(#46) Fix issues when lock files are attempted to be written in restricted directories

### DIFF
--- a/src/NuGet.Core/NuGet.Common/ConcurrencyUtilities.cs
+++ b/src/NuGet.Core/NuGet.Common/ConcurrencyUtilities.cs
@@ -36,7 +36,10 @@ namespace NuGet.Common
             CancellationToken token,
             string lockFileDirectoryPath)
         {
-            var originalBasePath = BasePath;
+            // We use the field here, as the BasePath variable
+            // will try to create a lock file, even if the path is not writable by the current user.
+            string originalBasePath = _basePath;
+
             BasePath = lockFileDirectoryPath;
 
             try

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
@@ -389,7 +389,7 @@ namespace NuGet.Packaging
                 // Start - Chocolatey Specific Modification
                 //////////////////////////////////////////////////////////
 
-                var lockDirectory = Path.GetDirectoryName(targetNupkg) ?? Environment.CurrentDirectory;
+                var lockDirectory = Path.GetDirectoryName(targetPath) ?? Environment.CurrentDirectory;
 
                 //////////////////////////////////////////////////////////
                 // End - Chocolatey Specific Modification
@@ -645,7 +645,7 @@ namespace NuGet.Packaging
                 // Start - Chocolatey Specific Modification
                 //////////////////////////////////////////////////////////
 
-                var lockDirectory = Path.GetDirectoryName(targetNupkg) ?? Environment.CurrentDirectory;
+                var lockDirectory = Path.GetDirectoryName(targetPath) ?? Environment.CurrentDirectory;
 
                 //////////////////////////////////////////////////////////
                 // End - Chocolatey Specific Modification


### PR DESCRIPTION
## Description Of Changes

THe changes in this PR are related to the changes that was made in 3.4.1.
Among these changes it corrects the location to write lock files to when a package gets extracted. It was incorrectly using the directory of a nupkg file, which caused issues when the file gets downloaded to this location as NuGet.Client attempts to clean out the directory first, which would cause a process denied exception due to the lock file being there.

Additionally, the use of the BasePath in the ConcurrentUtility has also been fixed by not using the Property that may cause an exception to occur when it is set to a restricted directory, and instead use the field that have no additional logic behind it.

## Motivation and Context

To fix non-admins not being able download packages, and to fix the bug in 3.4.1 that causes certain installation operations to fail due to the incorrect folder being used for lock files.

## Testing

1. Pull down latest changes in this PR.
2. Pull down the latest changes in Chocolatey CLI.
3. Create a debug version of NuGet.Client and copy it over to Chocolatey CLI.
4. (Elevated) Run `choco config set cacheLocation "$env:ChocolateyInstall\choco-cache"`
5. (Elevated) Run `choco install pester --version 5.3.0` (or a lower version if 5.3.0 is latest on your sources)
6. Verify installation was successful
7. (Elevated) Run `choco upgrade pester`
8. Verify upgrade was successful
9. (Elevated) Run `choco uninstall pester`
10. Remove the directory `$env:ChocolateyInstall\choco-cache\ChocolateyScratch`
11. Install latest version of Chocolatey Licensed Extension (unofficial build)
12. (Non-Elevated) Run `choco dowload pester --version 5.3.0` (or a lower version if 5.3.0 is latest on your sources)
13. Verify the download was successful
14. (Non-Elevated) Run `choco download pester --force`
15. Verify the download was successful

### Operating Systems Testing

- Windows 10
- Windows Server 2022

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #46
