### PR TITLE
(#51) Remove hard coded entry for starts with

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedQueryBuilder.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedQueryBuilder.cs
@@ -58,7 +58,7 @@ namespace NuGet.Protocol
         private const string ExactFilterFormat = "tolower(Id)%20eq%20'{0}'";
         private const string ByIdOnlyFormat = "substringof('{0}',tolower(Id))";
         private const string ByTagOnlyFormat = "substringof('{0}',Tags)";
-        private const string IdStartsWithFormat = "startswith(tolower(Id),'chocolatey')";
+        private const string IdStartsWithFormat = "startswith(tolower(Id),'{0}')";
 
         //////////////////////////////////////////////////////////
         // End - Chocolatey Specific Modification


### PR DESCRIPTION
## Description Of Changes

This updates the format that is being used when we try to search for an
id that starts with something.

This is done by updating the format to not use a hard coded instance of
`chocolatey`.

## Motivation and Context

By having a hard coded value, we are not able to properly search for an id that starts with something.

## Testing

1. Pull in the changes to your local choco repository using the `update-nuget-client.ps1` script.
2. Attempt to search for a package using the argument for id starting with (example: `choco search sysinternals --id-starts-with`).
3. Verify the expected results are returned.

### Operating Systems Testing

- Windows 10

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #51
