### PR TITLE
(maint) Update versions used for building and releasing

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -13,7 +13,7 @@
     <!-- **  Change for each new version -->
     <!-- when changing any of the NuGetVersion props below, run tools-local\ship-public-apis -->
     <MajorNuGetVersion Condition="'$(MajorNuGetVersion)' == ''">3</MajorNuGetVersion>
-    <MinorNuGetVersion Condition="'$(MinorNuGetVersion)' == ''">5</MinorNuGetVersion>
+    <MinorNuGetVersion Condition="'$(MinorNuGetVersion)' == ''">6</MinorNuGetVersion>
     <PatchNuGetVersion Condition="'$(PatchNuGetVersion)' == ''">0</PatchNuGetVersion>
     <SemanticVersion Condition=" '$(SemanticVersion)' == '' ">$(MajorNuGetVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</SemanticVersion>
 

--- a/tools-local/ship-public-apis/ship-public-apis.csproj
+++ b/tools-local/ship-public-apis/ship-public-apis.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>NuGet.Internal.Tools.ShipPublicApis</RootNamespace>
     <Description>Copy and merge contents of PublicAPI.Unshipped.txt to PublicAPI.Shipped.txt. See https://github.com/NuGet/NuGet.Client/tree/dev/docs/nuget-sdk.md#Shipping_NuGet for more details.</Description>
   </PropertyGroup>


### PR DESCRIPTION
## Description Of Changes

- Update the building version of NuGet.Client to be 3.6.0 on develop.
- Update the target framework version used by `ship-public-apis` to be the latest LTS of .Net.

## Motivation and Context

Preparing for future released.

## Testing

- Run `.\build.ps1 -CI -SkipUnitTest -ChocolateyBuild -BuildNumber 12 -ReleaseLabel final -BuildDate (Get-Date -Format "yyyyMMdd")` and ensure it builds a 3.6.0 based version.
- Ran `dotnet run` in the `tools-local/ship-public-apis` directory during the release of 3.5.0.

### Operating Systems Testing

Dev VM 4

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

N/A